### PR TITLE
chore: update resource id rule

### DIFF
--- a/checkfield/checkfield.go
+++ b/checkfield/checkfield.go
@@ -216,8 +216,8 @@ func CheckResourceID(id string) error {
 		return fmt.Errorf("`id` is not allowed to be a UUID")
 	}
 
-	if match, _ := regexp.MatchString("^[a-z_][a-z_0-9]{0,31}$", id); !match {
-		return fmt.Errorf("the ID must consist only of lowercase letters, numbers, or underscores, and its length cannot exceed 32 characters")
+	if match, _ := regexp.MatchString("^[a-z_][-a-z_0-9]{0,31}$", id); !match {
+		return fmt.Errorf("the ID must start with a lowercase letter or underscore, followed by zero to 31 occurrences of lowercase letters, numbers, hyphens, or underscores.")
 	}
 	return nil
 }

--- a/checkfield/checkfield_test.go
+++ b/checkfield/checkfield_test.go
@@ -357,7 +357,7 @@ func TestCheckResourceID_InvalidShort(t *testing.T) {
 	// 0-charactor string
 	tooShort := ""
 	err := checkfield.CheckResourceID(tooShort)
-	require.EqualError(t, err, "the ID must consist only of lowercase letters, numbers, or underscores, and its length cannot exceed 32 characters")
+	require.EqualError(t, err, "the ID must start with a lowercase letter or underscore, followed by zero to 31 occurrences of lowercase letters, numbers, hyphens, or underscores.")
 }
 
 func TestCheckResourceID_InvalidLong(t *testing.T) {
@@ -365,7 +365,7 @@ func TestCheckResourceID_InvalidLong(t *testing.T) {
 	// 64-charactor string
 	tooLong := "abcdefghijklmnopqrstuvwxyz-ABCDEFGHIJKLMNOPQRSTUVWXYZ-0123456789"
 	err := checkfield.CheckResourceID(tooLong)
-	require.EqualError(t, err, "the ID must consist only of lowercase letters, numbers, or underscores, and its length cannot exceed 32 characters")
+	require.EqualError(t, err, "the ID must start with a lowercase letter or underscore, followed by zero to 31 occurrences of lowercase letters, numbers, hyphens, or underscores.")
 }
 
 func TestCheckResourceID_InvalidUUID(t *testing.T) {
@@ -375,7 +375,7 @@ func TestCheckResourceID_InvalidUUID(t *testing.T) {
 }
 
 func TestCheckResourceID_Invalid(t *testing.T) {
-	a := "local-user"
+	a := "local[user"
 	err := checkfield.CheckResourceID(a)
-	require.EqualError(t, err, "the ID must consist only of lowercase letters, numbers, or underscores, and its length cannot exceed 32 characters")
+	require.EqualError(t, err, "the ID must start with a lowercase letter or underscore, followed by zero to 31 occurrences of lowercase letters, numbers, hyphens, or underscores.")
 }


### PR DESCRIPTION
Because

- we'd like to allow hyphen as resource id

This commit

- update resource id rule
