### PR TITLE
feat: collect shared logic for blob storage and minio

### DIFF
--- a/blobstorage/blobstorage.go
+++ b/blobstorage/blobstorage.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 
 	"google.golang.org/grpc/metadata"
@@ -37,7 +38,9 @@ func UploadFile(ctx context.Context, uploadURL string, data []byte, contentType 
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("upload failed with status %d: %s", resp.StatusCode, string(body))
+		log.Printf("upload failed with status %d", resp.StatusCode)
+		log.Printf("response body: %s", string(body))
+		return fmt.Errorf("upload failed")
 	}
 
 	return nil

--- a/blobstorage/blobstorage.go
+++ b/blobstorage/blobstorage.go
@@ -1,0 +1,58 @@
+package blobstorage
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"google.golang.org/grpc/metadata"
+)
+
+func UploadFile(ctx context.Context, uploadURL string, data []byte, contentType string) error {
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, nil)
+
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	body := bytes.NewReader(data)
+	contentLength := int64(len(data))
+	req.Body = io.NopCloser(body)
+	req.Header = metadataToHTTPHeaders(ctx)
+
+	req.ContentLength = contentLength
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Del("Authorization")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+
+	if err != nil {
+		return fmt.Errorf("uploading blob: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("upload failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+func metadataToHTTPHeaders(ctx context.Context) http.Header {
+	headers := http.Header{}
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		return headers
+	}
+	for key, values := range md {
+		for _, value := range values {
+			headers.Add(key, value)
+		}
+	}
+	return headers
+}

--- a/blobstorage/blobstorage_test.go
+++ b/blobstorage/blobstorage_test.go
@@ -1,0 +1,2 @@
+// TODO: add test for blobstorage
+package blobstorage


### PR DESCRIPTION
Because

- blob storage will be used in different service

This commit

- collect get and upload data function

Note
- For minio pkg, the current pkg is not fit with the current design of blob storage. We will refactor that part with run logging.
- We will need to add the test code