### PR TITLE
chore(vdp): add uploading URL logger and skip TLS verification

### DIFF
--- a/blobstorage/blobstorage.go
+++ b/blobstorage/blobstorage.go
@@ -3,6 +3,7 @@ package blobstorage
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -28,7 +29,11 @@ func UploadFile(ctx context.Context, logger *zap.Logger, uploadURL string, data 
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Del("Authorization")
 
-	client := &http.Client{}
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
 	resp, err := client.Do(req)
 
 	if err != nil {

--- a/blobstorage/blobstorage.go
+++ b/blobstorage/blobstorage.go
@@ -42,6 +42,7 @@ func UploadFile(ctx context.Context, logger *zap.Logger, uploadURL string, data 
 		logger.Error("Failed to upload file to MinIO",
 			zap.Binary("body", body),
 			zap.Int("status", resp.StatusCode),
+			zap.String("Uploading URL", uploadURL),
 			zap.Error(err),
 		)
 		return err


### PR DESCRIPTION
Because

- the logger is not clear

This commit

- add the logger
- skip TLS verification for blobstorage
