### PR TITLE
feat(minio): test minio package on CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,12 +3,21 @@ name: Coverage
 on: [push, pull_request]
 
 jobs:
-
   codecov:
     name: codecov
     runs-on: ubuntu-latest
+    services:
+      minio:
+        # edge-cicd is a modified image that doesn't require us to pass the `server` command when running the container.
+        image: minio/minio:edge-cicd
+        options: >-
+          --health-cmd "curl http://localhost:9000/minio/health/live"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 19000:9000
     steps:
-
       - uses: actions/checkout@v4
 
       - name: Load .env file

--- a/minio/minio_test.go
+++ b/minio/minio_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestMinio(t *testing.T) {
-	t.Skipf("only for testing on local")
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION
Because

- `minio` package tests were skipped because they depended on a MinIO instance running.

This commit

- Add a MinIO service to the CI/CD action.
