### PR TITLE
chore(minio): do not configure MinIO with root credentials

### DIFF
--- a/minio/config.go
+++ b/minio/config.go
@@ -4,8 +4,8 @@ package minio
 type Config struct {
 	Host       string `koanf:"host"`
 	Port       string `koanf:"port"`
-	RootUser   string `koanf:"rootuser"`
-	RootPwd    string `koanf:"rootpwd"`
+	User       string `koanf:"user"`
+	Password   string `koanf:"password"`
 	BucketName string `koanf:"bucketname"`
 	Secure     bool   `koanf:"secure"` // Add this line for the Secure option
 }

--- a/minio/minio.go
+++ b/minio/minio.go
@@ -81,7 +81,7 @@ func NewMinioClientAndInitBucket(ctx context.Context, params ClientParams) (Mini
 
 	endpoint := net.JoinHostPort(cfg.Host, cfg.Port)
 	client, err := miniogo.New(endpoint, &miniogo.Options{
-		Creds:  credentials.NewStaticV4(cfg.RootUser, cfg.RootPwd, ""),
+		Creds:  credentials.NewStaticV4(cfg.User, cfg.Password, ""),
 		Secure: cfg.Secure,
 	})
 	if err != nil {
@@ -359,7 +359,7 @@ func NewMinioClient(ctx context.Context, cfg *Config, logger *zap.Logger) (*mini
 
 	endpoint := net.JoinHostPort(cfg.Host, cfg.Port)
 	client, err := miniogo.New(endpoint, &miniogo.Options{
-		Creds:  credentials.NewStaticV4(cfg.RootUser, cfg.RootPwd, ""),
+		Creds:  credentials.NewStaticV4(cfg.User, cfg.Password, ""),
 		Secure: cfg.Secure,
 	})
 	if err != nil {

--- a/minio/minio_test.go
+++ b/minio/minio_test.go
@@ -22,8 +22,8 @@ func TestMinio(t *testing.T) {
 		Config: miniox.Config{
 			Host:       "localhost",
 			Port:       "19000",
-			RootUser:   "minioadmin",
-			RootPwd:    "minioadmin",
+			User:       "minioadmin",
+			Password:   "minioadmin",
 			BucketName: "instill-ai-model",
 		},
 	}


### PR DESCRIPTION
Because

- MinIO config params lead to the conclusion that the root credentials are needed, when any valid user/pass with the right permissions (bucket & object) will be valid.

This commit

- Updates the configuration for the MinIO client.
