### PR TITLE
feat(temporal): add context propagator

### DIFF
--- a/constant/constant.go
+++ b/constant/constant.go
@@ -1,9 +1,23 @@
 package constant
 
 const (
-	HeaderUserUIDKey      = "Instill-User-Uid"
+	// HeaderUserUIDKey is the context key for the authenticated user.
+	HeaderUserUIDKey = "Instill-User-Uid"
+	// HeaderRequesterUIDKey is the context key for the requester. An
+	// authenticated user can use different namespaces (e.g. an organization
+	// they belong to) to make requests, as long as they have permissions.
 	HeaderRequesterUIDKey = "Instill-Requester-Uid"
-	HeaderUserAgent       = "Instill-User-Agent"
+	// HeaderVisitorUIDKey is the context key for the visitor UID when requests
+	// are made without authentication.
+	HeaderVisitorUIDKey = "Instill-Visitor-Uid"
+	// HeaderAuthTypeKey is the context key the authentication type (user or
+	// visitor).
+	HeaderAuthTypeKey = "Instill-Auth-Type"
+	// HeaderUserAgentKey identifies the agent that's making a request. Its
+	// accepted values are the string values of
+	// github.com/instill-ai/protogen-go/common/run/v1alpha.RunSource.
+	HeaderUserAgentKey = "Instill-User-Agent"
 
+	// ContentTypeJSON is the value for the JSON content type.
 	ContentTypeJSON = "application/json"
 )

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -10,15 +10,18 @@ import (
 	"github.com/instill-ai/x/constant"
 )
 
-// GetRequestSingleHeader get a request header, the header has to be single-value HTTP header
-func GetRequestSingleHeader(ctx context.Context, header string) string {
-	metaHeader := metadata.ValueFromIncomingContext(ctx, strings.ToLower(header))
+// GetRequestSingleHeader gets a request header, assuming the value is a
+// single-value string HTTP header.
+func GetRequestSingleHeader(ctx context.Context, key string) string {
+	metaHeader := metadata.ValueFromIncomingContext(ctx, strings.ToLower(key))
 	if len(metaHeader) != 1 {
 		return ""
 	}
 	return metaHeader[0]
 }
 
+// GetRequesterUIDAndUserUID extracts the requester and user UIDs from the
+// request header.
 func GetRequesterUIDAndUserUID(ctx context.Context) (uuid.UUID, uuid.UUID) {
 	requesterUID := GetRequestSingleHeader(ctx, constant.HeaderRequesterUIDKey)
 	userUID := GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)

--- a/temporal/propagator.go
+++ b/temporal/propagator.go
@@ -1,0 +1,136 @@
+package temporal
+
+import (
+	"context"
+	"strings"
+
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/workflow"
+	"google.golang.org/grpc/metadata"
+)
+
+type (
+	// contextKey is an unexported type used as key for items stored in the
+	// Context object.
+	contextKey struct{}
+
+	// propagator implements a custom context propagator for Temporal.
+	propagator struct{}
+
+	keyValuePair struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	}
+)
+
+const headerKey = "instill-metadata"
+
+// NewContextPropagator returns a context propagator that propagates a set of
+// string key-value pairs across a workflow.
+func NewContextPropagator() workflow.ContextPropagator {
+	return &propagator{}
+}
+
+// Inject injects values from context into headers for propagation.
+func (s *propagator) Inject(ctx context.Context, writer workflow.HeaderWriter) error {
+	value := ctx.Value(contextKey{})
+	payload, err := converter.GetDefaultDataConverter().ToPayload(value)
+	if err != nil {
+		return err
+	}
+	writer.Set(headerKey, payload)
+	return nil
+}
+
+// InjectFromWorkflow injects values from context into headers for propagation.
+func (s *propagator) InjectFromWorkflow(ctx workflow.Context, writer workflow.HeaderWriter) error {
+	value := ctx.Value(contextKey{})
+	payload, err := converter.GetDefaultDataConverter().ToPayload(value)
+	if err != nil {
+		return err
+	}
+	writer.Set(headerKey, payload)
+	return nil
+}
+
+// Extract extracts values from headers and puts them into context.
+func (s *propagator) Extract(ctx context.Context, reader workflow.HeaderReader) (context.Context, error) {
+	if raw, ok := reader.Get(headerKey); ok {
+		var values []keyValuePair
+		if err := converter.GetDefaultDataConverter().FromPayload(raw, &values); err != nil {
+			return ctx, nil
+		}
+		ctx = context.WithValue(ctx, contextKey{}, values)
+	}
+
+	return ctx, nil
+}
+
+// ExtractToWorkflow extracts values from headers and puts them into context.
+func (s *propagator) ExtractToWorkflow(ctx workflow.Context, reader workflow.HeaderReader) (workflow.Context, error) {
+	if raw, ok := reader.Get(headerKey); ok {
+		var values []keyValuePair
+		if err := converter.GetDefaultDataConverter().FromPayload(raw, &values); err != nil {
+			return ctx, nil
+		}
+		ctx = workflow.WithValue(ctx, contextKey{}, values)
+	}
+
+	return ctx, nil
+}
+
+type valueGetter interface {
+	Value(key any) any
+}
+
+// ValueFromPropagatedContext returns the value in the propagated
+// context.Context corresponding to the provided key. Keys are matched in a
+// case insensitive manner.
+func ValueFromPropagatedContext(ctx valueGetter, key string) string {
+	propagatedValues, ok := ctx.Value(contextKey{}).([]keyValuePair)
+	if !ok {
+		return ""
+	}
+
+	for _, kv := range propagatedValues {
+		if strings.EqualFold(key, kv.Key) {
+			return kv.Value
+		}
+	}
+
+	return ""
+}
+
+// PropagateValue adds a key-value pair to the propagation key in the context.
+func PropagateValue(ctx context.Context, k string, v string) context.Context {
+	propagatedValues, _ := ctx.Value(contextKey{}).([]keyValuePair)
+
+	newValues := make([]keyValuePair, len(propagatedValues)+1)
+	copy(newValues, propagatedValues)
+	newValues[len(newValues)-1] = keyValuePair{Key: strings.ToLower(k), Value: v}
+
+	return context.WithValue(ctx, contextKey{}, newValues)
+}
+
+// PropagateMetadata adds the key-value pairs present in the context metadata
+// (coming from gRPC or HTTP requests via gRPC Gateway) to the propagation key
+// in the context. If a key has more than one value, only the first one will be
+// copied to replicate the behaviour in the x/resource package.
+func PropagateMetadata(ctx context.Context) context.Context {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx
+	}
+
+	propagatedValues, _ := ctx.Value(contextKey{}).([]keyValuePair)
+	newValues := make([]keyValuePair, len(propagatedValues)+len(md))
+	copy(newValues, propagatedValues)
+
+	i := len(propagatedValues)
+	for k, v := range md {
+		newValues[i] = keyValuePair{Key: k, Value: v[0]}
+		i++
+	}
+
+	return context.WithValue(ctx, contextKey{}, newValues)
+}

--- a/temporal/propagator_test.go
+++ b/temporal/propagator_test.go
@@ -1,0 +1,115 @@
+package temporal
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+	"google.golang.org/grpc/metadata"
+
+	qt "github.com/frankban/quicktest"
+	commonpb "go.temporal.io/api/common/v1"
+)
+
+var propagatedValues = []keyValuePair{
+	{Key: "k1", Value: "v1"},
+	{Key: "k2", Value: "v2"},
+	{Key: "k3", Value: "v3"},
+}
+
+func Test_CtxPropWorkflow(t *testing.T) {
+	c := qt.New(t)
+
+	ts := new(testsuite.WorkflowTestSuite)
+	payload, _ := converter.GetDefaultDataConverter().ToPayload(propagatedValues)
+	ts.SetHeader(&commonpb.Header{
+		Fields: map[string]*commonpb.Payload{
+			headerKey: payload,
+		},
+	})
+
+	env := ts.NewTestWorkflowEnvironment()
+	env.SetContextPropagators([]workflow.ContextPropagator{NewContextPropagator()})
+	env.RegisterActivity(SampleActivity)
+
+	got := make([]string, 0, len(propagatedValues))
+	env.SetOnActivityStartedListener(func(activityInfo *activity.Info, ctx context.Context, args converter.EncodedValues) {
+		// The key should be propagated by custom context propagator.
+		for _, kv := range propagatedValues {
+			got = append(got, ValueFromPropagatedContext(ctx, kv.Key))
+		}
+	})
+
+	env.ExecuteWorkflow(CtxPropWorkflow)
+	c.Check(env.IsWorkflowCompleted(), qt.IsTrue)
+	c.Check(env.GetWorkflowError(), qt.IsNil)
+
+	c.Check(got, qt.HasLen, len(propagatedValues))
+
+	for i, want := range propagatedValues {
+		c.Check(got[i], qt.Equals, want.Value)
+	}
+}
+
+func Test_PropagateValue(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := context.Background()
+	for _, kv := range propagatedValues {
+		ctx = PropagateValue(ctx, kv.Key, kv.Value)
+	}
+
+	for i, want := range propagatedValues {
+		// Test case-insensitivity.
+		k := want.Key
+		if i == 1 {
+			k = strings.ToUpper(k)
+		}
+
+		got := ValueFromPropagatedContext(ctx, k)
+		c.Check(got, qt.Equals, want.Value)
+	}
+}
+
+func Test_PropagateMetadata(t *testing.T) {
+	c := qt.New(t)
+
+	metadataMap := map[string]string{
+		"foo": "bar",
+		"pim": "pam",
+		"tic": "tac",
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(metadataMap))
+	ctx = PropagateMetadata(ctx)
+
+	for k, want := range metadataMap {
+		got := ValueFromPropagatedContext(ctx, k)
+		c.Check(got, qt.Equals, want)
+	}
+}
+func SampleActivity(_ context.Context) error {
+	return nil
+}
+
+func CtxPropWorkflow(ctx workflow.Context) error {
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: 100 * time.Millisecond,
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	for _, want := range propagatedValues {
+		got := ValueFromPropagatedContext(ctx, want.Key)
+		if got != want.Value {
+			return fmt.Errorf("unexpected propagated value for %s: %s", want.Key, got)
+		}
+	}
+
+	return workflow.ExecuteActivity(ctx, SampleActivity).Get(ctx, nil)
+}


### PR DESCRIPTION
This commit

- Adds a [context propagator](https://docs.temporal.io/develop/go/observability#context-propagation) to the `x/temporal` package.
- This can be used to pass headers from the Temporal client to workflows and activities.
- A method to propagate the gRPC metadata in the context (from HTTP or gRPC request headers) is included.
