### PR TITLE
chore(server): improve server package

### DIFF
--- a/checkfield/checkfield.go
+++ b/checkfield/checkfield.go
@@ -14,10 +14,10 @@ import (
 // CheckRequiredFields implements follows https://google.aip.dev/203#required
 // The msg parameter is a Protobuf message instance
 // The requiredFields is a slice of field path with snake_case name
-func CheckRequiredFields(msg interface{}, requiredFields []string) error {
+func CheckRequiredFields(msg any, requiredFields []string) error {
 
-	var recurMsgCheck func(interface{}, []string, string) error
-	recurMsgCheck = func(m interface{}, fieldNames []string, path string) error {
+	var recurMsgCheck func(any, []string, string) error
+	recurMsgCheck = func(m any, fieldNames []string, path string) error {
 
 		if reflect.ValueOf(m).IsZero() {
 			return fmt.Errorf("required field path `%s` is empty", path)
@@ -76,10 +76,10 @@ func CheckRequiredFields(msg interface{}, requiredFields []string) error {
 // CheckCreateOutputOnlyFields implements follows https://google.aip.dev/203#output-only
 // The msg parameter is a Protobuf message instance
 // The outputOnlyFields is a slice of field path with snake_case name
-func CheckCreateOutputOnlyFields(msg interface{}, outputOnlyFields []string) error {
+func CheckCreateOutputOnlyFields(msg any, outputOnlyFields []string) error {
 
-	var recurMsgCheck func(interface{}, []string, string) error
-	recurMsgCheck = func(m interface{}, fieldNames []string, path string) error {
+	var recurMsgCheck func(any, []string, string) error
+	recurMsgCheck = func(m any, fieldNames []string, path string) error {
 
 		if reflect.ValueOf(m).IsZero() {
 			return fmt.Errorf("output-only field path `%s` is empty", path)
@@ -126,10 +126,10 @@ func CheckCreateOutputOnlyFields(msg interface{}, outputOnlyFields []string) err
 // CheckUpdateImmutableFields implements follows https://google.aip.dev/203#immutable
 // The msgReq parameter is a Protobuf message instance requested to update msgUpdate
 // The outputOnlyFields is a slice of field path with snake_case name
-func CheckUpdateImmutableFields(msgReq interface{}, msgUpdate interface{}, immutableFields []string) error {
+func CheckUpdateImmutableFields(msgReq any, msgUpdate any, immutableFields []string) error {
 
-	var recurMsgCheck func(interface{}, interface{}, []string, string) error
-	recurMsgCheck = func(mr interface{}, mu interface{}, fieldNames []string, path string) error {
+	var recurMsgCheck func(any, any, []string, string) error
+	recurMsgCheck = func(mr any, mu any, fieldNames []string, path string) error {
 
 		if reflect.ValueOf(mr).IsZero() {
 			return fmt.Errorf("immutable field path `%s` in request message is empty", path)

--- a/client/grpc/middleware.go
+++ b/client/grpc/middleware.go
@@ -12,7 +12,7 @@ import (
 func MetadataPropagatorInterceptor(
 	ctx context.Context,
 	method string,
-	req, reply interface{},
+	req, reply any,
 	cc *grpc.ClientConn,
 	invoker grpc.UnaryInvoker,
 	opts ...grpc.CallOption,

--- a/log/adapter_test.go
+++ b/log/adapter_test.go
@@ -258,7 +258,7 @@ func TestZapAdapter_ComplexValues(t *testing.T) {
 	adapter := NewZapAdapter(testLogger)
 
 	// Test with complex values
-	complexMap := map[string]interface{}{"nested": "value"}
+	complexMap := map[string]any{"nested": "value"}
 	complexSlice := []string{"item1", "item2"}
 
 	adapter.Info("complex values", "map", complexMap, "slice", complexSlice, "nil", nil)
@@ -268,8 +268,8 @@ func TestZapAdapter_ComplexValues(t *testing.T) {
 
 	fields := logs[0].ContextMap()
 	assert.Equal(t, complexMap, fields["map"])
-	// Convert []interface{} to []string for comparison
-	sliceInterface := fields["slice"].([]interface{})
+	// Convert []any to []string for comparison
+	sliceInterface := fields["slice"].([]any)
 	sliceString := make([]string, len(sliceInterface))
 	for i, v := range sliceInterface {
 		sliceString[i] = v.(string)

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -255,7 +255,7 @@ func TestColoredJSONEncoder_EncodeEntry(t *testing.T) {
 			cleanOutput = strings.ReplaceAll(cleanOutput, "\x1b[0m", "")
 
 			// Parse as JSON to ensure it's valid
-			var logEntry map[string]interface{}
+			var logEntry map[string]any
 			err = json.Unmarshal([]byte(cleanOutput), &logEntry)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.message, logEntry["msg"])

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,600 @@
+# server
+
+A comprehensive gRPC server framework with built-in interceptors, logging, tracing, and gateway support.
+
+The `x/server` package provides a production-ready gRPC server setup with comprehensive middleware support, including logging, tracing, error handling, and gRPC-Gateway integration. It's designed to work seamlessly with the Instill AI platform and follows best practices for observability and error handling.
+
+## Overview
+
+The `x/server` package provides:
+
+1. **Pre-configured gRPC server options** - Ready-to-use server configuration with sensible defaults
+2. **Comprehensive interceptor chain** - Built-in logging, tracing, error handling, and recovery
+3. **Flexible logging control** - Configurable method exclusion patterns for selective logging
+4. **OpenTelemetry integration** - Automatic tracing and metrics collection
+5. **gRPC-Gateway support** - HTTP/JSON gateway with custom error handling
+6. **TLS/SSL support** - Secure communication with certificate-based authentication
+
+## Core Components
+
+### gRPC Server Options (`options.go`)
+
+The main entry point for creating gRPC server configurations with all necessary interceptors and options.
+
+#### `NewGRPCOptionAndCreds(options ...Option) ([]grpc.ServerOption, credentials.TransportCredentials, error)`
+
+Creates a complete gRPC server configuration with:
+
+- **Interceptor chain**: Metadata, decider, tracing, and recovery interceptors
+- **TLS credentials**: Automatic certificate-based security
+- **OpenTelemetry integration**: Built-in tracing and metrics
+- **Message size limits**: Configurable payload size limits
+
+```go
+// Basic usage
+opts, creds, err := grpc.NewGRPCOptionAndCreds(
+    grpc.WithServiceName("my-service"),
+    grpc.WithServiceVersion("v1.0.0"),
+    grpc.WithOTELCollectorEnable(true),
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+server := grpc.NewServer(opts...)
+```
+
+#### Configuration Options
+
+```go
+// Service configuration
+grpc.WithServiceConfig(client.HTTPSConfig{
+    Cert: "/path/to/cert.pem",
+    Key:  "/path/to/key.pem",
+})
+
+// Service metadata
+grpc.WithServiceName("my-service")
+grpc.WithServiceVersion("v1.0.0")
+
+// Observability
+grpc.WithOTELCollectorEnable(true)
+
+// Logging control
+grpc.WithMethodExcludePatterns([]string{
+    "*.Health/*",
+    "*.Metrics/*",
+})
+```
+
+### Interceptors
+
+#### 1. Metadata Interceptor (`metadata.go`)
+
+Handles gRPC metadata propagation and error conversion.
+
+**UnaryAppendMetadataAndErrorCodeInterceptor**
+
+- Preserves incoming metadata in context
+- Converts errors to gRPC status errors using `x/errors.ConvertToGRPCError`
+
+**StreamAppendMetadataInterceptor**
+
+- Handles metadata for streaming RPCs
+- Wraps stream context with metadata
+
+#### 2. Decider Interceptor (`decider.go`)
+
+Controls which gRPC calls should be logged based on method patterns.
+
+**Default Exclusions:**
+
+```go
+var DefaultMethodExcludePatterns = []string{
+    "*PublicService/.*ness$",  // Health checks
+    "*PrivateService/.*$",     // Private service calls
+}
+```
+
+**Usage:**
+
+```go
+// Custom exclusion patterns
+patterns := []string{
+    "*.Health/*",
+    "*.Metrics/*",
+    "*.Internal/*",
+}
+
+interceptor := interceptor.DeciderUnaryServerInterceptor(patterns)
+```
+
+#### 3. Tracing Interceptor (`trace.go`)
+
+Provides comprehensive request logging with trace context and OpenTelemetry integration.
+
+**Features:**
+
+- **Structured logging**: JSON-formatted logs with trace IDs
+- **Performance metrics**: Request duration tracking
+- **Error categorization**: Automatic log level selection based on gRPC codes
+- **OpenTelemetry support**: Dual logging to both Zap and OTEL
+
+**Log Levels by gRPC Code:**
+
+- `codes.OK` → Info
+- `codes.Canceled`, `codes.DeadlineExceeded`, etc. → Warn
+- `codes.InvalidArgument`, `codes.NotFound`, etc. → Error
+
+**Example Log Output:**
+
+```json
+{
+  "level": "info",
+  "msg": "finished unary call CreateUser (trace_id: 1234567890abcdef)",
+  "timestamp": "2024-01-01T12:00:00Z",
+  "duration": "15.2ms"
+}
+```
+
+#### 4. Recovery Interceptor (`recovery.go`)
+
+Handles panics and converts them to gRPC errors.
+
+```go
+// Automatically recovers from panics
+// Converts panic values to gRPC status errors
+// Prevents server crashes from unhandled panics
+```
+
+### gRPC-Gateway Support (`gateway/`)
+
+Provides HTTP/JSON gateway functionality with custom error handling and response modification.
+
+#### HTTPResponseModifier
+
+Modifies HTTP responses based on gRPC metadata:
+
+- Sets custom HTTP status codes via `x-http-code` header
+- Removes internal headers from responses
+
+#### ErrorHandler
+
+Custom error handling for HTTP responses:
+
+- Converts gRPC errors to appropriate HTTP status codes
+- Provides structured error responses
+- Handles authentication headers (`WWW-Authenticate`)
+
+#### CustomHeaderMatcher
+
+Controls which HTTP headers are forwarded to gRPC:
+
+- JWT headers (`jwt-*`)
+- Instill headers (`instill-*`)
+- GitHub headers (`x-github*`)
+- Standard headers (`accept`, `request-id`, etc.)
+
+## API Reference
+
+### Core Functions
+
+#### `grpc.NewGRPCOptionAndCreds(options ...Option) ([]grpc.ServerOption, credentials.TransportCredentials, error)`
+
+Creates gRPC server options and credentials.
+
+**Parameters:**
+
+- `options`: Configuration options (see Options section)
+
+**Returns:**
+
+- `[]grpc.ServerOption`: Server options for `grpc.NewServer()`
+- `credentials.TransportCredentials`: TLS credentials (if configured)
+- `error`: Any configuration errors
+
+#### `interceptor.DeciderUnaryServerInterceptor(patterns []string) grpc.UnaryServerInterceptor`
+
+Creates a unary interceptor that controls logging based on method patterns.
+
+**Parameters:**
+
+- `patterns`: Regex patterns for methods to exclude from logging
+
+#### `interceptor.TracingUnaryServerInterceptor(serviceName, serviceVersion string, otelEnable bool) grpc.UnaryServerInterceptor`
+
+Creates a unary interceptor for request tracing and logging.
+
+**Parameters:**
+
+- `serviceName`: Service identifier for logs
+- `serviceVersion`: Service version for logs
+- `otelEnable`: Enable OpenTelemetry logging
+
+#### `gateway.HTTPResponseModifier(ctx context.Context, w http.ResponseWriter, p proto.Message) error`
+
+Modifies HTTP responses based on gRPC metadata.
+
+#### `gateway.ErrorHandler(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, w http.ResponseWriter, r *http.Request, err error)`
+
+Handles gRPC errors in HTTP responses.
+
+### Configuration Options
+
+#### `grpc.WithServiceConfig(config client.HTTPSConfig)`
+
+Sets TLS/SSL configuration.
+
+```go
+config := client.HTTPSConfig{
+    Cert: "/path/to/cert.pem",
+    Key:  "/path/to/key.pem",
+}
+```
+
+#### `grpc.WithServiceName(name string)`
+
+Sets the service name for logging and tracing.
+
+#### `grpc.WithServiceVersion(version string)`
+
+Sets the service version for logging and tracing.
+
+#### `grpc.WithOTELCollectorEnable(enable bool)`
+
+Enables or disables OpenTelemetry collector integration.
+
+#### `grpc.WithMethodExcludePatterns(patterns []string)`
+
+Sets custom method exclusion patterns for logging.
+
+## Usage Examples
+
+### Basic gRPC Server Setup
+
+```go
+package main
+
+import (
+    "log"
+    "net"
+
+    "google.golang.org/grpc"
+    "github.com/instill-ai/x/server/grpc"
+)
+
+func main() {
+    // Create server options
+    opts, creds, err := grpc.NewGRPCOptionAndCreds(
+        grpc.WithServiceName("user-service"),
+        grpc.WithServiceVersion("v1.0.0"),
+        grpc.WithOTELCollectorEnable(true),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Create gRPC server
+    server := grpc.NewServer(opts...)
+
+    // Register your services
+    // pb.RegisterUserServiceServer(server, &userService{})
+
+    // Start server
+    lis, err := net.Listen("tcp", ":50051")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Server listening on :50051")
+    if err := server.Serve(lis); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+### gRPC Server with TLS
+
+```go
+// Create server options with TLS
+opts, creds, err := grpc.NewGRPCOptionAndCreds(
+    grpc.WithServiceName("secure-service"),
+    grpc.WithServiceVersion("v1.0.0"),
+    grpc.WithServiceConfig(client.HTTPSConfig{
+        Cert: "/path/to/server.crt",
+        Key:  "/path/to/server.key",
+    }),
+    grpc.WithOTELCollectorEnable(true),
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+// creds contains the TLS credentials
+log.Printf("TLS enabled: %v", creds != nil)
+```
+
+### Custom Logging Patterns
+
+```go
+// Exclude health checks and metrics from logging
+opts, _, err := grpc.NewGRPCOptionAndCreds(
+    grpc.WithServiceName("api-service"),
+    grpc.WithMethodExcludePatterns([]string{
+        "*.Health/*",
+        "*.Metrics/*",
+        "*.Internal/*",
+        "*.Debug/*",
+    }),
+)
+```
+
+### gRPC-Gateway Setup
+
+```go
+package main
+
+import (
+    "context"
+    "net/http"
+
+    "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
+
+    "github.com/instill-ai/x/server/grpc/gateway"
+    pb "your-project/proto"
+)
+
+func main() {
+    // Create gRPC client connection
+    conn, err := grpc.DialContext(
+        context.Background(),
+        "localhost:50051",
+        grpc.WithTransportCredentials(insecure.NewCredentials()),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer conn.Close()
+
+    // Create gRPC-Gateway mux
+    mux := runtime.NewServeMux(
+        runtime.WithForwardResponseOption(gateway.HTTPResponseModifier),
+        runtime.WithErrorHandler(gateway.ErrorHandler),
+        runtime.WithIncomingHeaderMatcher(gateway.CustomHeaderMatcher),
+    )
+
+    // Register your gRPC service
+    if err := pb.RegisterUserServiceHandler(context.Background(), mux, conn); err != nil {
+        log.Fatal(err)
+    }
+
+    // Start HTTP server
+    log.Printf("Gateway listening on :8080")
+    if err := http.ListenAndServe(":8080", mux); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+### Custom Interceptor Chain
+
+```go
+// Create custom interceptor chain
+unaryInterceptors := grpcmiddleware.ChainUnaryServer(
+    interceptor.UnaryAppendMetadataAndErrorCodeInterceptor,
+    interceptor.DeciderUnaryServerInterceptor([]string{"*.Health/*"}),
+    interceptor.TracingUnaryServerInterceptor("my-service", "v1.0.0", true),
+    grpcrecovery.UnaryServerInterceptor(interceptor.RecoveryInterceptorOpt()),
+    // Add your custom interceptors here
+)
+
+streamInterceptors := grpcmiddleware.ChainStreamServer(
+    interceptor.StreamAppendMetadataInterceptor,
+    interceptor.DeciderStreamServerInterceptor([]string{"*.Health/*"}),
+    interceptor.TracingStreamServerInterceptor("my-service", "v1.0.0", true),
+    grpcrecovery.StreamServerInterceptor(interceptor.RecoveryInterceptorOpt()),
+    // Add your custom interceptors here
+)
+
+server := grpc.NewServer(
+    grpc.UnaryInterceptor(unaryInterceptors),
+    grpc.StreamInterceptor(streamInterceptors),
+)
+```
+
+## Best Practices
+
+### 1. Service Configuration
+
+- **Use descriptive service names**: Help with log aggregation and tracing
+- **Version your services**: Enable tracking of service versions in logs
+- **Enable OpenTelemetry**: For production observability
+
+```go
+opts, _, err := grpc.NewGRPCOptionAndCreds(
+    grpc.WithServiceName("user-management-service"),
+    grpc.WithServiceVersion("v2.1.0"),
+    grpc.WithOTELCollectorEnable(true),
+)
+```
+
+### 2. Logging Strategy
+
+- **Exclude noisy endpoints**: Health checks, metrics, and internal calls
+- **Use consistent patterns**: Standardize method exclusion patterns across services
+- **Monitor log volume**: Adjust patterns based on actual usage
+
+```go
+// Recommended exclusion patterns
+patterns := []string{
+    "*.Health/*",           // Health checks
+    "*.Metrics/*",          // Metrics endpoints
+    "*.Internal/*",         // Internal service calls
+    "*.Debug/*",            // Debug endpoints
+    "*PublicService/.*ness$", // Liveness/readiness checks
+}
+```
+
+### 3. Error Handling
+
+- **Use x/errors package**: Leverage the integrated error handling
+- **Preserve error context**: Let interceptors handle error conversion
+- **Monitor error rates**: Use the built-in error categorization
+
+```go
+// In your service handlers, use x/errors
+import "github.com/instill-ai/x/errors"
+
+func (s *Service) CreateUser(ctx context.Context, req *pb.CreateUserRequest) (*pb.CreateUserResponse, error) {
+    if err := s.validateUser(req); err != nil {
+        return nil, errors.AddMessage(err, "Please check your input and try again.")
+    }
+
+    // The interceptor will automatically convert this to gRPC status
+    return s.repo.CreateUser(ctx, req)
+}
+```
+
+### 4. Security
+
+- **Use TLS in production**: Always configure certificates for production
+- **Validate certificates**: Ensure proper certificate validation
+- **Monitor security events**: Use the built-in logging for security monitoring
+
+```go
+// Production TLS configuration
+config := client.HTTPSConfig{
+    Cert: "/etc/ssl/certs/server.crt",
+    Key:  "/etc/ssl/private/server.key",
+}
+
+opts, creds, err := grpc.NewGRPCOptionAndCreds(
+    grpc.WithServiceConfig(config),
+    // ... other options
+)
+```
+
+### 5. Observability
+
+- **Enable OpenTelemetry**: For comprehensive tracing and metrics
+- **Monitor request patterns**: Use the built-in request logging
+- **Track performance**: Leverage the automatic duration tracking
+
+```go
+// Enable full observability
+opts, _, err := grpc.NewGRPCOptionAndCreds(
+    grpc.WithOTELCollectorEnable(true),
+    grpc.WithServiceName("my-service"),
+    grpc.WithServiceVersion("v1.0.0"),
+)
+```
+
+### 6. Testing
+
+- **Test interceptor behavior**: Verify logging and error handling
+- **Mock external dependencies**: Use the provided mock utilities
+- **Test error scenarios**: Ensure proper error conversion and logging
+
+```go
+func TestService_WithInterceptors(t *testing.T) {
+    // Use the provided mock utilities
+    mockLogger := &interceptor.MockLogger{}
+
+    // Test your service with interceptors
+    // Verify logging behavior and error handling
+}
+```
+
+## Migration Guide
+
+### From Standard gRPC Server
+
+**Before:**
+
+```go
+server := grpc.NewServer()
+// Manual interceptor setup
+// Manual error handling
+// Manual logging
+```
+
+**After:**
+
+```go
+opts, _, err := grpc.NewGRPCOptionAndCreds(
+    grpc.WithServiceName("my-service"),
+    grpc.WithServiceVersion("v1.0.0"),
+    grpc.WithOTELCollectorEnable(true),
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+server := grpc.NewServer(opts...)
+// Automatic interceptor chain
+// Automatic error handling
+// Automatic structured logging
+```
+
+### Adding Custom Interceptors
+
+```go
+// Create base options
+opts, _, err := grpc.NewGRPCOptionAndCreds(
+    grpc.WithServiceName("my-service"),
+)
+
+// Add custom interceptors
+unaryInterceptors := append([]grpc.UnaryServerInterceptor{
+    myCustomInterceptor,
+}, opts...)
+
+server := grpc.NewServer(grpc.UnaryInterceptor(unaryInterceptors...))
+```
+
+## Performance Considerations
+
+- **Minimal overhead**: Interceptors are optimized for performance
+- **Selective logging**: Use exclusion patterns to reduce log volume
+- **Efficient error handling**: Error conversion is optimized for common cases
+- **Memory efficient**: Context propagation is designed for minimal allocations
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Missing TLS certificates**: Ensure certificate files exist and are readable
+2. **Log volume too high**: Adjust method exclusion patterns
+3. **OpenTelemetry not working**: Verify OTEL collector is running and accessible
+4. **gRPC-Gateway errors**: Check header matcher configuration
+
+### Debug Mode
+
+Enable debug logging to troubleshoot interceptor behavior:
+
+```go
+// Set log level to debug
+log.SetLevel(zap.DebugLevel)
+
+// Check interceptor chain
+opts, _, err := grpc.NewGRPCOptionAndCreds(
+    grpc.WithServiceName("debug-service"),
+    grpc.WithOTELCollectorEnable(false), // Disable OTEL for debugging
+)
+```
+
+## Contributing
+
+When adding new functionality:
+
+1. **Follow existing patterns**: Use the established interceptor patterns
+2. **Add comprehensive tests**: Include unit tests for new interceptors
+3. **Update documentation**: Keep this README current with new features
+4. **Consider performance**: Ensure new interceptors don't impact performance
+5. **Add examples**: Provide usage examples for new features
+
+## License
+
+This package is part of the Instill AI x library and follows the same licensing terms.

--- a/server/grpc/gateway/misc_test.go
+++ b/server/grpc/gateway/misc_test.go
@@ -1,0 +1,516 @@
+package gateway
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/instill-ai/x/constant"
+
+	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// Mock marshaler for testing
+type mockMarshaler struct {
+	contentType string
+	marshalErr  error
+}
+
+func (m *mockMarshaler) ContentType(any) string {
+	return m.contentType
+}
+
+func (m *mockMarshaler) Marshal(any) ([]byte, error) {
+	if m.marshalErr != nil {
+		return nil, m.marshalErr
+	}
+	return []byte(`{"test": "data"}`), nil
+}
+
+func (m *mockMarshaler) Unmarshal([]byte, any) error {
+	return nil
+}
+
+func (m *mockMarshaler) NewDecoder(r io.Reader) runtime.Decoder {
+	return &mockDecoder{}
+}
+
+func (m *mockMarshaler) NewEncoder(w io.Writer) runtime.Encoder {
+	return &mockEncoder{}
+}
+
+type mockDecoder struct{}
+
+func (d *mockDecoder) Decode(v any) error {
+	return nil
+}
+
+type mockEncoder struct{}
+
+func (e *mockEncoder) Encode(v any) error {
+	return nil
+}
+
+func TestHTTPResponseModifier(t *testing.T) {
+	tests := []struct {
+		name          string
+		headerMD      metadata.MD
+		expectedCode  int
+		expectedError bool
+		description   string
+	}{
+		{
+			name:          "no server metadata",
+			headerMD:      nil,
+			expectedCode:  200, // default
+			expectedError: false,
+			description:   "should return nil when no server metadata exists",
+		},
+		{
+			name: "valid http code",
+			headerMD: metadata.New(map[string]string{
+				"x-http-code": "201",
+			}),
+			expectedCode:  201,
+			expectedError: false,
+			description:   "should set http status code from metadata",
+		},
+		{
+			name: "invalid http code",
+			headerMD: metadata.New(map[string]string{
+				"x-http-code": "invalid",
+			}),
+			expectedCode:  200, // default
+			expectedError: true,
+			description:   "should return error for invalid http code",
+		},
+		{
+			name: "no x-http-code header",
+			headerMD: metadata.New(map[string]string{
+				"other-header": "value",
+			}),
+			expectedCode:  200, // default
+			expectedError: false,
+			description:   "should not modify response when x-http-code is not present",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create context with or without server metadata
+			ctx := context.Background()
+			if tt.headerMD != nil {
+				ctx = runtime.NewServerMetadataContext(ctx, runtime.ServerMetadata{
+					HeaderMD: tt.headerMD,
+				})
+			}
+
+			// Create response writer
+			w := httptest.NewRecorder()
+
+			// Call HTTPResponseModifier
+			err := HTTPResponseModifier(ctx, w, &emptypb.Empty{})
+
+			// Verify results
+			if tt.expectedError {
+				assert.Error(t, err, tt.description)
+			} else {
+				assert.NoError(t, err, tt.description)
+				assert.Equal(t, tt.expectedCode, w.Code, tt.description)
+			}
+		})
+	}
+}
+
+func TestErrorHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            error
+		contentType    string
+		marshalErr     error
+		teHeader       string
+		headerMD       metadata.MD
+		trailerMD      metadata.MD
+		expectedStatus int
+		description    string
+	}{
+		{
+			name:           "successful error handling",
+			err:            status.Error(codes.InvalidArgument, "invalid argument"),
+			contentType:    "application/json",
+			marshalErr:     nil,
+			teHeader:       "",
+			expectedStatus: 200, // default
+			description:    "should handle error successfully",
+		},
+		{
+			name:           "unauthenticated error",
+			err:            status.Error(codes.Unauthenticated, "unauthorized"),
+			contentType:    "application/json",
+			marshalErr:     nil,
+			teHeader:       "",
+			expectedStatus: 200, // default
+			description:    "should set WWW-Authenticate header for unauthenticated error",
+		},
+		{
+			name:           "marshal error",
+			err:            status.Error(codes.Internal, "internal error"),
+			contentType:    "application/json",
+			marshalErr:     assert.AnError,
+			teHeader:       "",
+			expectedStatus: 500,
+			description:    "should return 500 when marshal fails",
+		},
+		{
+			name:           "with trailers",
+			err:            status.Error(codes.OK, "success"),
+			contentType:    "application/json",
+			marshalErr:     nil,
+			teHeader:       "trailers",
+			headerMD:       metadata.New(map[string]string{"test-header": "value"}),
+			trailerMD:      metadata.New(map[string]string{"test-trailer": "value"}),
+			expectedStatus: 200, // default
+			description:    "should handle trailers when TE header includes trailers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create context with server metadata
+			ctx := context.Background()
+			serverMD := runtime.ServerMetadata{}
+			if tt.headerMD != nil {
+				serverMD.HeaderMD = tt.headerMD
+			}
+			if tt.trailerMD != nil {
+				serverMD.TrailerMD = tt.trailerMD
+			}
+			ctx = runtime.NewServerMetadataContext(ctx, serverMD)
+
+			// Create request with TE header
+			req := httptest.NewRequest("GET", "/test", nil)
+			if tt.teHeader != "" {
+				req.Header.Set("TE", tt.teHeader)
+			}
+
+			// Create response writer
+			w := httptest.NewRecorder()
+
+			// Create mock marshaler
+			marshaler := &mockMarshaler{
+				contentType: tt.contentType,
+				marshalErr:  tt.marshalErr,
+			}
+
+			// Create mock mux
+			mux := &runtime.ServeMux{}
+
+			// Call ErrorHandler
+			ErrorHandler(ctx, mux, marshaler, w, req, tt.err)
+
+			// Verify results
+			if tt.err != nil {
+				s := status.Convert(tt.err)
+				if s.Code() == codes.Unauthenticated {
+					assert.Equal(t, s.Message(), w.Header().Get("WWW-Authenticate"), tt.description)
+				}
+
+				if tt.contentType == "application/json" {
+					assert.Equal(t, "application/problem+json", w.Header().Get("Content-Type"), tt.description)
+				} else {
+					assert.Equal(t, tt.contentType, w.Header().Get("Content-Type"), tt.description)
+				}
+
+				if tt.marshalErr != nil {
+					assert.Equal(t, http.StatusInternalServerError, w.Code, tt.description)
+				}
+
+				if tt.teHeader != "" && strings.Contains(strings.ToLower(tt.teHeader), "trailers") {
+					assert.Equal(t, "chunked", w.Header().Get("Transfer-Encoding"), tt.description)
+				}
+			}
+		})
+	}
+}
+
+func TestCustomHeaderMatcher(t *testing.T) {
+	tests := []struct {
+		name          string
+		key           string
+		expectedKey   string
+		expectedMatch bool
+		description   string
+	}{
+		{
+			name:          "jwt header",
+			key:           "jwt-token",
+			expectedKey:   "jwt-token",
+			expectedMatch: true,
+			description:   "should match jwt- prefixed headers",
+		},
+		{
+			name:          "jwt header case insensitive",
+			key:           "JWT-TOKEN",
+			expectedKey:   "JWT-TOKEN",
+			expectedMatch: true,
+			description:   "should match jwt- prefixed headers case insensitive",
+		},
+		{
+			name:          "instill header",
+			key:           "instill-version",
+			expectedKey:   "instill-version",
+			expectedMatch: true,
+			description:   "should match instill- prefixed headers",
+		},
+		{
+			name:          "github header",
+			key:           "x-github-event",
+			expectedKey:   "x-github-event",
+			expectedMatch: true,
+			description:   "should match x-github prefixed headers",
+		},
+		{
+			name:          "accept header",
+			key:           "accept",
+			expectedKey:   "accept",
+			expectedMatch: true,
+			description:   "should match accept header",
+		},
+		{
+			name:          "request-id header",
+			key:           "request-id",
+			expectedKey:   "request-id",
+			expectedMatch: true,
+			description:   "should match request-id header",
+		},
+		{
+			name:          "traceparent header",
+			key:           "traceparent",
+			expectedKey:   "traceparent",
+			expectedMatch: true,
+			description:   "should match traceparent header",
+		},
+		{
+			name:          "tracestate header",
+			key:           "tracestate",
+			expectedKey:   "tracestate",
+			expectedMatch: true,
+			description:   "should match tracestate header",
+		},
+		{
+			name:          "unknown header",
+			key:           "unknown-header",
+			expectedKey:   "",
+			expectedMatch: false,
+			description:   "should not match unknown headers",
+		},
+		{
+			name:          "empty key",
+			key:           "",
+			expectedKey:   "",
+			expectedMatch: false,
+			description:   "should not match empty key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, match := CustomHeaderMatcher(tt.key)
+			assert.Equal(t, tt.expectedKey, key, tt.description)
+			assert.Equal(t, tt.expectedMatch, match, tt.description)
+		})
+	}
+}
+
+func TestInjectOwnerToContext(t *testing.T) {
+	tests := []struct {
+		name        string
+		owner       *mgmtpb.User
+		expected    map[string]string
+		description string
+	}{
+		{
+			name: "valid owner",
+			owner: &mgmtpb.User{
+				Uid: stringPtr("test-user-123"),
+			},
+			expected: map[string]string{
+				constant.HeaderAuthTypeKey: "user",
+				constant.HeaderUserUIDKey:  "test-user-123",
+			},
+			description: "should inject owner metadata to context",
+		},
+		{
+			name:  "nil owner",
+			owner: nil,
+			expected: map[string]string{
+				constant.HeaderAuthTypeKey: "user",
+				constant.HeaderUserUIDKey:  "",
+			},
+			description: "should handle nil owner gracefully",
+		},
+		{
+			name: "empty uid",
+			owner: &mgmtpb.User{
+				Uid: stringPtr(""),
+			},
+			expected: map[string]string{
+				constant.HeaderAuthTypeKey: "user",
+				constant.HeaderUserUIDKey:  "",
+			},
+			description: "should handle empty uid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			resultCtx := InjectOwnerToContext(ctx, tt.owner)
+
+			// Extract metadata from context
+			md, ok := metadata.FromOutgoingContext(resultCtx)
+			assert.True(t, ok, tt.description)
+
+			// Verify expected metadata
+			for key, expectedValue := range tt.expected {
+				values := md.Get(key)
+				if expectedValue == "" {
+					// For empty expected values, check if the key exists but has empty value
+					if len(values) > 0 {
+						assert.Equal(t, "", values[0], tt.description)
+					}
+				} else {
+					assert.Len(t, values, 1, tt.description)
+					assert.Equal(t, expectedValue, values[0], tt.description)
+				}
+			}
+		})
+	}
+}
+
+// Test error handling edge cases
+func TestErrorHandlerEdgeCases(t *testing.T) {
+	// Test with nil error
+	ctx := context.Background()
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	marshaler := &mockMarshaler{contentType: "application/json"}
+	mux := &runtime.ServeMux{}
+
+	ErrorHandler(ctx, mux, marshaler, w, req, nil)
+	// Should not panic and should handle gracefully
+	assert.NotNil(t, w)
+
+	// Test with context without server metadata
+	ctx = context.Background()
+	req = httptest.NewRequest("GET", "/test", nil)
+	w = httptest.NewRecorder()
+	err := status.Error(codes.Internal, "test error")
+
+	ErrorHandler(ctx, mux, marshaler, w, req, err)
+	// Should handle gracefully even without server metadata
+	assert.NotNil(t, w)
+}
+
+// Test header manipulation in HTTPResponseModifier
+func TestHTTPResponseModifierHeaderManipulation(t *testing.T) {
+	// Create context with server metadata containing x-http-code
+	headerMD := metadata.New(map[string]string{
+		"x-http-code": "404",
+	})
+	ctx := runtime.NewServerMetadataContext(context.Background(), runtime.ServerMetadata{
+		HeaderMD: headerMD,
+	})
+
+	w := httptest.NewRecorder()
+
+	// Call HTTPResponseModifier
+	err := HTTPResponseModifier(ctx, w, &emptypb.Empty{})
+	assert.NoError(t, err)
+
+	// Verify that the header was deleted from the response
+	assert.Empty(t, w.Header().Get("Grpc-Metadata-X-Http-Code"))
+	assert.Equal(t, 404, w.Code)
+}
+
+// Test trailer handling in ErrorHandler
+func TestErrorHandlerTrailerHandling(t *testing.T) {
+	// Create context with server metadata containing trailers
+	headerMD := metadata.New(map[string]string{"test-header": "header-value"})
+	trailerMD := metadata.New(map[string]string{"test-trailer": "trailer-value"})
+	ctx := runtime.NewServerMetadataContext(context.Background(), runtime.ServerMetadata{
+		HeaderMD:  headerMD,
+		TrailerMD: trailerMD,
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("TE", "trailers")
+	w := httptest.NewRecorder()
+	marshaler := &mockMarshaler{contentType: "application/json"}
+	mux := &runtime.ServeMux{}
+	err := status.Error(codes.OK, "success")
+
+	ErrorHandler(ctx, mux, marshaler, w, req, err)
+
+	// Verify trailer headers were set
+	assert.Equal(t, "chunked", w.Header().Get("Transfer-Encoding"))
+	assert.Contains(t, w.Header().Get("Trailer"), "Grpc-Trailer-Test-Trailer")
+}
+
+// Test content type handling in ErrorHandler
+func TestErrorHandlerContentTypeHandling(t *testing.T) {
+	tests := []struct {
+		name         string
+		contentType  string
+		expectedType string
+		description  string
+	}{
+		{
+			name:         "json content type",
+			contentType:  "application/json",
+			expectedType: "application/problem+json",
+			description:  "should convert application/json to application/problem+json",
+		},
+		{
+			name:         "xml content type",
+			contentType:  "application/xml",
+			expectedType: "application/xml",
+			description:  "should keep non-json content types unchanged",
+		},
+		{
+			name:         "empty content type",
+			contentType:  "",
+			expectedType: "",
+			description:  "should handle empty content type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			req := httptest.NewRequest("GET", "/test", nil)
+			w := httptest.NewRecorder()
+			marshaler := &mockMarshaler{contentType: tt.contentType}
+			mux := &runtime.ServeMux{}
+			err := status.Error(codes.InvalidArgument, "test error")
+
+			ErrorHandler(ctx, mux, marshaler, w, req, err)
+
+			assert.Equal(t, tt.expectedType, w.Header().Get("Content-Type"), tt.description)
+		})
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}

--- a/server/grpc/interceptor/decider.go
+++ b/server/grpc/interceptor/decider.go
@@ -1,0 +1,74 @@
+package interceptor
+
+import (
+	"context"
+	"regexp"
+
+	"google.golang.org/grpc"
+)
+
+type contextKey string
+
+const shouldLogKey contextKey = "shouldLog"
+
+// DefaultMethodExcludePatterns is always included in the methodExcludePatterns used for matching.
+var DefaultMethodExcludePatterns = []string{
+	// stop logging gRPC calls if it was a call to liveness or readiness and no error was raised
+	"*PublicService/.*ness$",
+	// stop logging gRPC calls if it was a call to a private function and no error was raised
+	"*PrivateService/.*$",
+}
+
+// DeciderUnaryServerInterceptor returns a unary interceptor that sets a shouldLog flag in context based on methodExcludePatterns.
+// DefaultMethodExcludePatterns is always included, and any provided methodExcludePatterns are appended.
+func DeciderUnaryServerInterceptor(methodExcludePatterns []string) grpc.UnaryServerInterceptor {
+	methods := append([]string{}, DefaultMethodExcludePatterns...)
+	methods = append(methods, methodExcludePatterns...)
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		shouldLog := decideLogGRPCRequest(info.FullMethod, methods, nil) // error is not available at this stage
+		ctx = context.WithValue(ctx, shouldLogKey, shouldLog)
+		return handler(ctx, req)
+	}
+}
+
+// DeciderStreamServerInterceptor returns a stream interceptor that sets a shouldLog flag in context based on methodExcludePatterns.
+// DefaultMethodExcludePatterns is always included, and any provided methodExcludePatterns are appended.
+func DeciderStreamServerInterceptor(methodExcludePatterns []string) grpc.StreamServerInterceptor {
+	methods := append([]string{}, DefaultMethodExcludePatterns...)
+	methods = append(methods, methodExcludePatterns...)
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		shouldLog := decideLogGRPCRequest(info.FullMethod, methods, nil) // error is not available at this stage
+		wrapped := &deciderServerStream{ServerStream: stream, ctx: context.WithValue(stream.Context(), shouldLogKey, shouldLog)}
+		return handler(srv, wrapped)
+	}
+}
+
+type deciderServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (d *deciderServerStream) Context() context.Context {
+	return d.ctx
+}
+
+// decideLogGRPCRequest returns true if the fullMethod matches any of methodExcludePatterns, otherwise false.
+func decideLogGRPCRequest(fullMethod string, methodExcludePatterns []string, err error) bool {
+	if err == nil {
+		for _, method := range methodExcludePatterns {
+			if match, _ := regexp.MatchString(method, fullMethod); match {
+				return true
+			}
+		}
+	}
+	return true
+}
+
+// ShouldLogFromContext returns the shouldLog flag from context, defaulting to true if not set
+func ShouldLogFromContext(ctx context.Context) bool {
+	shouldLog, ok := ctx.Value(shouldLogKey).(bool)
+	if !ok {
+		return true
+	}
+	return shouldLog
+}

--- a/server/grpc/interceptor/decider_test.go
+++ b/server/grpc/interceptor/decider_test.go
@@ -1,0 +1,296 @@
+package interceptor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+func TestDecideLogGRPCRequest(t *testing.T) {
+	tests := []struct {
+		name                  string
+		fullMethod            string
+		methodExcludePatterns []string
+		err                   error
+		expectedShouldLog     bool
+		description           string
+	}{
+		{
+			name:                  "no error, no patterns, should log",
+			fullMethod:            "test.Service/Method",
+			methodExcludePatterns: []string{},
+			err:                   nil,
+			expectedShouldLog:     true,
+			description:           "when no error and no exclude patterns, should log",
+		},
+		{
+			name:                  "no error, pattern matches, should log",
+			fullMethod:            "test.PublicService/liveness",
+			methodExcludePatterns: []string{"*PublicService/.*ness$"},
+			err:                   nil,
+			expectedShouldLog:     true, // matches pattern, so should log
+			description:           "when pattern matches, should log",
+		},
+		{
+			name:                  "no error, pattern does not match, should log",
+			fullMethod:            "test.Service/Method",
+			methodExcludePatterns: []string{"*PublicService/.*ness$"},
+			err:                   nil,
+			expectedShouldLog:     true,
+			description:           "when pattern does not match, should log",
+		},
+		{
+			name:                  "with error, pattern matches, should log",
+			fullMethod:            "test.PublicService/liveness",
+			methodExcludePatterns: []string{"*PublicService/.*ness$"},
+			err:                   assert.AnError,
+			expectedShouldLog:     true,
+			description:           "when there is an error, should always log regardless of patterns",
+		},
+		{
+			name:                  "multiple patterns, one matches",
+			fullMethod:            "test.PrivateService/method",
+			methodExcludePatterns: []string{"*PublicService/.*ness$", "*PrivateService/.*$"},
+			err:                   nil,
+			expectedShouldLog:     true, // matches second pattern
+			description:           "when one of multiple patterns matches, should log",
+		},
+		{
+			name:                  "multiple patterns, none match",
+			fullMethod:            "test.Service/method",
+			methodExcludePatterns: []string{"*PublicService/.*ness$", "*PrivateService/.*$"},
+			err:                   nil,
+			expectedShouldLog:     true,
+			description:           "when none of multiple patterns match, should log",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := decideLogGRPCRequest(tt.fullMethod, tt.methodExcludePatterns, tt.err)
+			assert.Equal(t, tt.expectedShouldLog, result, tt.description)
+		})
+	}
+}
+
+func TestDeciderUnaryServerInterceptor(t *testing.T) {
+	tests := []struct {
+		name                  string
+		methodExcludePatterns []string
+		fullMethod            string
+		expectedShouldLog     bool
+		description           string
+	}{
+		{
+			name:                  "nil patterns, uses defaults",
+			methodExcludePatterns: nil,
+			fullMethod:            "test.PublicService/liveness",
+			expectedShouldLog:     true, // matches default pattern
+			description:           "when nil patterns provided, should use default patterns",
+		},
+		{
+			name:                  "empty patterns, uses defaults",
+			methodExcludePatterns: []string{},
+			fullMethod:            "test.PrivateService/method",
+			expectedShouldLog:     true, // matches default pattern
+			description:           "when empty patterns provided, should use default patterns",
+		},
+		{
+			name:                  "custom patterns appended to defaults",
+			methodExcludePatterns: []string{"*CustomService/.*$"},
+			fullMethod:            "test.CustomService/method",
+			expectedShouldLog:     true, // matches custom pattern
+			description:           "when custom patterns provided, should append to defaults",
+		},
+		{
+			name:                  "default patterns still work with custom patterns",
+			methodExcludePatterns: []string{"*CustomService/.*$"},
+			fullMethod:            "test.PublicService/liveness",
+			expectedShouldLog:     true, // matches default pattern
+			description:           "default patterns should still work when custom patterns are provided",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interceptor := DeciderUnaryServerInterceptor(tt.methodExcludePatterns)
+
+			ctx := context.Background()
+			req := "test request"
+			info := &grpc.UnaryServerInfo{
+				FullMethod: tt.fullMethod,
+			}
+
+			var shouldLogValue bool
+			handler := func(ctx context.Context, req any) (any, error) {
+				shouldLogValue = ShouldLogFromContext(ctx)
+				return "response", nil
+			}
+
+			_, err := interceptor(ctx, req, info, handler)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedShouldLog, shouldLogValue, tt.description)
+		})
+	}
+}
+
+func TestDeciderStreamServerInterceptor(t *testing.T) {
+	tests := []struct {
+		name                  string
+		methodExcludePatterns []string
+		fullMethod            string
+		expectedShouldLog     bool
+		description           string
+	}{
+		{
+			name:                  "nil patterns, uses defaults",
+			methodExcludePatterns: nil,
+			fullMethod:            "test.PublicService/liveness",
+			expectedShouldLog:     true, // matches default pattern
+			description:           "when nil patterns provided, should use default patterns",
+		},
+		{
+			name:                  "empty patterns, uses defaults",
+			methodExcludePatterns: []string{},
+			fullMethod:            "test.PrivateService/method",
+			expectedShouldLog:     true, // matches default pattern
+			description:           "when empty patterns provided, should use default patterns",
+		},
+		{
+			name:                  "custom patterns appended to defaults",
+			methodExcludePatterns: []string{"*CustomService/.*$"},
+			fullMethod:            "test.CustomService/method",
+			expectedShouldLog:     true, // matches custom pattern
+			description:           "when custom patterns provided, should append to defaults",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interceptor := DeciderStreamServerInterceptor(tt.methodExcludePatterns)
+
+			ctx := context.Background()
+			stream := &MockServerStream{ctx: ctx}
+			info := &grpc.StreamServerInfo{
+				FullMethod: tt.fullMethod,
+			}
+
+			var shouldLogValue bool
+			handler := func(srv any, stream grpc.ServerStream) error {
+				shouldLogValue = ShouldLogFromContext(stream.Context())
+				return nil
+			}
+
+			err := interceptor(nil, stream, info, handler)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedShouldLog, shouldLogValue, tt.description)
+		})
+	}
+}
+
+func TestShouldLogFromContext(t *testing.T) {
+	tests := []struct {
+		name           string
+		ctx            context.Context
+		expectedResult bool
+		description    string
+	}{
+		{
+			name:           "context with shouldLog true",
+			ctx:            context.WithValue(context.Background(), shouldLogKey, true),
+			expectedResult: true,
+			description:    "when context has shouldLog=true, should return true",
+		},
+		{
+			name:           "context with shouldLog false",
+			ctx:            context.WithValue(context.Background(), shouldLogKey, false),
+			expectedResult: false,
+			description:    "when context has shouldLog=false, should return false",
+		},
+		{
+			name:           "context without shouldLog key",
+			ctx:            context.Background(),
+			expectedResult: true,
+			description:    "when context has no shouldLog key, should default to true",
+		},
+		{
+			name:           "context with wrong type value",
+			ctx:            context.WithValue(context.Background(), shouldLogKey, "not a bool"),
+			expectedResult: true,
+			description:    "when context has shouldLog key with wrong type, should default to true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ShouldLogFromContext(tt.ctx)
+			assert.Equal(t, tt.expectedResult, result, tt.description)
+		})
+	}
+}
+
+func TestDefaultMethodExcludePatterns(t *testing.T) {
+	// Test that default patterns are correctly defined
+	assert.Len(t, DefaultMethodExcludePatterns, 2)
+	assert.Contains(t, DefaultMethodExcludePatterns, "*PublicService/.*ness$")
+	assert.Contains(t, DefaultMethodExcludePatterns, "*PrivateService/.*$")
+}
+
+// Test that the deciderServerStream wrapper works correctly
+func TestDeciderServerStream(t *testing.T) {
+	originalCtx := context.Background()
+	originalStream := &MockServerStream{ctx: originalCtx}
+
+	wrappedStream := &deciderServerStream{
+		ServerStream: originalStream,
+		ctx:          context.WithValue(originalCtx, shouldLogKey, false),
+	}
+
+	// Test that Context() returns the wrapped context
+	wrappedCtx := wrappedStream.Context()
+	shouldLog := ShouldLogFromContext(wrappedCtx)
+	assert.False(t, shouldLog)
+
+	// Test that the original context is not affected
+	originalShouldLog := ShouldLogFromContext(originalCtx)
+	assert.True(t, originalShouldLog) // should default to true
+}
+
+// Test integration between interceptors and context
+func TestInterceptorIntegration(t *testing.T) {
+	// Test that the unary interceptor properly sets context
+	interceptor := DeciderUnaryServerInterceptor([]string{"*TestService/.*$"})
+
+	ctx := context.Background()
+	req := "test"
+	info := &grpc.UnaryServerInfo{FullMethod: "test.TestService/method"}
+
+	var capturedCtx context.Context
+	handler := func(ctx context.Context, req any) (any, error) {
+		capturedCtx = ctx
+		return nil, nil
+	}
+
+	_, err := interceptor(ctx, req, info, handler)
+	assert.NoError(t, err)
+
+	// Verify the context was modified
+	shouldLog := ShouldLogFromContext(capturedCtx)
+	assert.True(t, shouldLog) // should match the pattern
+
+	// Test with a method that doesn't match
+	info2 := &grpc.UnaryServerInfo{FullMethod: "test.OtherService/method"}
+	var capturedCtx2 context.Context
+	handler2 := func(ctx context.Context, req any) (any, error) {
+		capturedCtx2 = ctx
+		return nil, nil
+	}
+
+	_, err = interceptor(ctx, req, info2, handler2)
+	assert.NoError(t, err)
+
+	shouldLog2 := ShouldLogFromContext(capturedCtx2)
+	assert.True(t, shouldLog2) // should not match the pattern, but still log
+}

--- a/server/grpc/interceptor/mocks_test.go
+++ b/server/grpc/interceptor/mocks_test.go
@@ -1,0 +1,224 @@
+package interceptor
+
+import (
+	"context"
+	"io"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/stretchr/testify/mock"
+	"go.opentelemetry.io/otel/log"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// ============================================================================
+// Mock Proto Message
+// ============================================================================
+
+// MockProtoMessage is a mock proto message for testing
+type MockProtoMessage struct{}
+
+func (m *MockProtoMessage) Reset()                             {}
+func (m *MockProtoMessage) String() string                     { return "mock" }
+func (m *MockProtoMessage) ProtoMessage()                      {}
+func (m *MockProtoMessage) ProtoReflect() protoreflect.Message { return nil }
+
+// ============================================================================
+// Mock Logger
+// ============================================================================
+
+// MockLogger is a mock logger for testing
+type MockLogger struct {
+	mock.Mock
+}
+
+func (m *MockLogger) Info(msg string, fields ...zap.Field) {
+	m.Called(msg, fields)
+}
+
+func (m *MockLogger) Warn(msg string, fields ...zap.Field) {
+	m.Called(msg, fields)
+}
+
+func (m *MockLogger) Error(msg string, fields ...zap.Field) {
+	m.Called(msg, fields)
+}
+
+func (m *MockLogger) Debug(msg string, fields ...zap.Field) {
+	m.Called(msg, fields)
+}
+
+// ============================================================================
+// Mock OTEL Logger
+// ============================================================================
+
+// MockOTELLogger is a mock OTEL logger for testing
+type MockOTELLogger struct {
+	mock.Mock
+}
+
+func (m *MockOTELLogger) Emit(ctx context.Context, record log.Record) {
+	m.Called(ctx, record)
+}
+
+// ============================================================================
+// Mock Server Stream
+// ============================================================================
+
+// MockServerStream is a mock server stream for testing
+type MockServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (m *MockServerStream) Context() context.Context {
+	return m.ctx
+}
+
+func (m *MockServerStream) RecvMsg(msg interface{}) error {
+	return nil
+}
+
+func (m *MockServerStream) SendMsg(msg interface{}) error {
+	return nil
+}
+
+func (m *MockServerStream) SendHeader(md metadata.MD) error {
+	return nil
+}
+
+func (m *MockServerStream) SetHeader(md metadata.MD) error {
+	return nil
+}
+
+func (m *MockServerStream) SetTrailer(md metadata.MD) {
+}
+
+// ============================================================================
+// Mock Marshaler
+// ============================================================================
+
+// MockMarshaler is a mock marshaler for testing
+type MockMarshaler struct {
+	contentType string
+	marshalErr  error
+}
+
+func (m *MockMarshaler) ContentType(interface{}) string {
+	return m.contentType
+}
+
+func (m *MockMarshaler) Marshal(interface{}) ([]byte, error) {
+	if m.marshalErr != nil {
+		return nil, m.marshalErr
+	}
+	return []byte(`{"test": "data"}`), nil
+}
+
+func (m *MockMarshaler) Unmarshal([]byte, interface{}) error {
+	return nil
+}
+
+func (m *MockMarshaler) NewDecoder(r io.Reader) runtime.Decoder {
+	return &MockDecoder{}
+}
+
+func (m *MockMarshaler) NewEncoder(w io.Writer) runtime.Encoder {
+	return &MockEncoder{}
+}
+
+// ============================================================================
+// Mock Decoder
+// ============================================================================
+
+// MockDecoder is a mock decoder for testing
+type MockDecoder struct{}
+
+func (d *MockDecoder) Decode(v interface{}) error {
+	return nil
+}
+
+// ============================================================================
+// Mock Encoder
+// ============================================================================
+
+// MockEncoder is a mock encoder for testing
+type MockEncoder struct{}
+
+func (e *MockEncoder) Encode(v interface{}) error {
+	return nil
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+// StringPtr returns a pointer to the given string
+func StringPtr(s string) *string {
+	return &s
+}
+
+// ============================================================================
+// Common Test Data
+// ============================================================================
+
+// Common test data that can be reused across tests
+var (
+	// TestProtoMessage is a common proto message for testing
+	TestProtoMessage = &emptypb.Empty{}
+
+	// TestContext is a common context for testing
+	TestContext = context.Background()
+
+	// TestFullMethod is a common full method name for testing
+	TestFullMethod = "test.Service/Method"
+
+	// TestServiceName is a common service name for testing
+	TestServiceName = "test-service"
+
+	// TestServiceVersion is a common service version for testing
+	TestServiceVersion = "v1.0.0"
+)
+
+// ============================================================================
+// Test Utilities
+// ============================================================================
+
+// CreateTestContext creates a context with optional shouldLog flag
+func CreateTestContext(shouldLog bool) context.Context {
+	ctx := context.Background()
+	if !shouldLog {
+		ctx = context.WithValue(ctx, shouldLogKey, false)
+	}
+	return ctx
+}
+
+// CreateTestServerStream creates a mock server stream with the given context
+func CreateTestServerStream(ctx context.Context) *MockServerStream {
+	return &MockServerStream{ctx: ctx}
+}
+
+// CreateTestUnaryServerInfo creates a mock unary server info
+func CreateTestUnaryServerInfo(fullMethod string) *grpc.UnaryServerInfo {
+	return &grpc.UnaryServerInfo{
+		FullMethod: fullMethod,
+	}
+}
+
+// CreateTestStreamServerInfo creates a mock stream server info
+func CreateTestStreamServerInfo(fullMethod string) *grpc.StreamServerInfo {
+	return &grpc.StreamServerInfo{
+		FullMethod: fullMethod,
+	}
+}
+
+// CreateTestMarshaler creates a mock marshaler with the given configuration
+func CreateTestMarshaler(contentType string, marshalErr error) *MockMarshaler {
+	return &MockMarshaler{
+		contentType: contentType,
+		marshalErr:  marshalErr,
+	}
+}

--- a/server/grpc/interceptor/recovery_test.go
+++ b/server/grpc/interceptor/recovery_test.go
@@ -1,0 +1,255 @@
+package interceptor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+)
+
+func TestRecoveryInterceptorOpt(t *testing.T) {
+	// Test that RecoveryInterceptorOpt returns a valid option
+	opt := RecoveryInterceptorOpt()
+	assert.NotNil(t, opt, "RecoveryInterceptorOpt should return a non-nil option")
+
+	// Test that the option can be used to create interceptors
+	unaryInterceptor := grpc_recovery.UnaryServerInterceptor(opt)
+	assert.NotNil(t, unaryInterceptor, "should create unary interceptor with the option")
+}
+
+func TestRecoveryHandler(t *testing.T) {
+	tests := []struct {
+		name         string
+		panicValue   any
+		expectedCode codes.Code
+		expectedMsg  string
+		description  string
+	}{
+		{
+			name:         "string panic",
+			panicValue:   "test panic",
+			expectedCode: codes.Unknown,
+			expectedMsg:  "panic triggered: test panic",
+			description:  "should handle string panic values",
+		},
+		{
+			name:         "error panic",
+			panicValue:   errors.New("test error"),
+			expectedCode: codes.Unknown,
+			expectedMsg:  "panic triggered: test error",
+			description:  "should handle error panic values",
+		},
+		{
+			name:         "nil panic",
+			panicValue:   nil,
+			expectedCode: codes.Unknown,
+			expectedMsg:  "panic triggered: panic called with nil argument",
+			description:  "should handle nil panic values",
+		},
+		{
+			name:         "int panic",
+			panicValue:   42,
+			expectedCode: codes.Unknown,
+			expectedMsg:  "panic triggered: 42",
+			description:  "should handle int panic values",
+		},
+		{
+			name:         "struct panic",
+			panicValue:   struct{ Name string }{Name: "test"},
+			expectedCode: codes.Unknown,
+			expectedMsg:  "panic triggered: {test}",
+			description:  "should handle struct panic values",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Get the recovery option
+			opt := RecoveryInterceptorOpt()
+
+			// Extract the recovery handler from the option
+			// This is a bit tricky since we need to access the internal handler
+			// We'll test it by creating a recovery interceptor and triggering a panic
+
+			// Create unary recovery interceptor
+			unaryInterceptor := grpc_recovery.UnaryServerInterceptor(opt)
+
+			// Create a handler that panics with the test value
+			panicHandler := func(ctx context.Context, req any) (any, error) {
+				panic(tt.panicValue)
+			}
+
+			// Create mock request info
+			info := &grpc.UnaryServerInfo{
+				FullMethod: "test.Service/Method",
+			}
+
+			// Call the interceptor and expect it to recover
+			resp, err := unaryInterceptor(context.Background(), "test request", info, panicHandler)
+
+			// Verify the response is nil (panic was recovered)
+			assert.Nil(t, resp, tt.description)
+
+			// Verify the error is a gRPC status error
+			assert.Error(t, err, tt.description)
+			st, ok := status.FromError(err)
+			assert.True(t, ok, tt.description)
+			assert.Equal(t, tt.expectedCode, st.Code(), tt.description)
+			assert.Equal(t, tt.expectedMsg, st.Message(), tt.description)
+		})
+	}
+}
+
+func TestRecoveryInterceptorIntegration(t *testing.T) {
+	// Test that the recovery interceptor works in a real scenario
+	opt := RecoveryInterceptorOpt()
+	unaryInterceptor := grpc_recovery.UnaryServerInterceptor(opt)
+
+	// Test successful handler (no panic)
+	successHandler := func(ctx context.Context, req any) (any, error) {
+		return "success", nil
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "test.Service/SuccessMethod",
+	}
+
+	resp, err := unaryInterceptor(context.Background(), "test request", info, successHandler)
+	assert.NoError(t, err, "should not error for successful handler")
+	assert.Equal(t, "success", resp, "should return success response")
+
+	// Test handler that returns an error (no panic)
+	errorHandler := func(ctx context.Context, req any) (any, error) {
+		return nil, status.Error(codes.InvalidArgument, "invalid argument")
+	}
+
+	resp, err = unaryInterceptor(context.Background(), "test request", info, errorHandler)
+	assert.Error(t, err, "should return error from handler")
+	assert.Nil(t, resp, "should return nil response when handler errors")
+	st, ok := status.FromError(err)
+	assert.True(t, ok, "should be a gRPC status error")
+	assert.Equal(t, codes.InvalidArgument, st.Code(), "should preserve original error code")
+}
+
+func TestRecoveryInterceptorStream(t *testing.T) {
+	// Test stream recovery interceptor
+	opt := RecoveryInterceptorOpt()
+	streamInterceptor := grpc_recovery.StreamServerInterceptor(opt)
+
+	// Test stream handler that panics
+	panicStreamHandler := func(srv any, stream grpc.ServerStream) error {
+		panic("stream panic")
+	}
+
+	info := &grpc.StreamServerInfo{
+		FullMethod: "test.Service/StreamMethod",
+	}
+
+	// Create a mock stream
+	mockStream := &MockServerStream{ctx: context.Background()}
+
+	// Call the interceptor and expect it to recover
+	err := streamInterceptor(nil, mockStream, info, panicStreamHandler)
+
+	// Verify the error is a gRPC status error
+	assert.Error(t, err, "should return error for panic")
+	st, ok := status.FromError(err)
+	assert.True(t, ok, "should be a gRPC status error")
+	assert.Equal(t, codes.Unknown, st.Code(), "should return Unknown code for panic")
+	assert.Equal(t, "panic triggered: stream panic", st.Message(), "should have correct panic message")
+}
+
+func TestRecoveryInterceptorNilPanic(t *testing.T) {
+	// Test recovery from nil panic
+	opt := RecoveryInterceptorOpt()
+	unaryInterceptor := grpc_recovery.UnaryServerInterceptor(opt)
+
+	nilPanicHandler := func(ctx context.Context, req any) (any, error) {
+		panic(nil)
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "test.Service/NilPanicMethod",
+	}
+
+	resp, err := unaryInterceptor(context.Background(), "test request", info, nilPanicHandler)
+
+	assert.Nil(t, resp, "should return nil response for nil panic")
+	assert.Error(t, err, "should return error for nil panic")
+	st, ok := status.FromError(err)
+	assert.True(t, ok, "should be a gRPC status error")
+	assert.Equal(t, codes.Unknown, st.Code(), "should return Unknown code for nil panic")
+	assert.Equal(t, "panic triggered: panic called with nil argument", st.Message(), "should handle nil panic correctly")
+}
+
+func TestRecoveryInterceptorComplexPanic(t *testing.T) {
+	// Test recovery from complex panic values
+	opt := RecoveryInterceptorOpt()
+	unaryInterceptor := grpc_recovery.UnaryServerInterceptor(opt)
+
+	complexPanicHandler := func(ctx context.Context, req any) (any, error) {
+		panic(map[string]interface{}{
+			"error":   "complex error",
+			"code":    500,
+			"details": []string{"detail1", "detail2"},
+		})
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "test.Service/ComplexPanicMethod",
+	}
+
+	resp, err := unaryInterceptor(context.Background(), "test request", info, complexPanicHandler)
+
+	assert.Nil(t, resp, "should return nil response for complex panic")
+	assert.Error(t, err, "should return error for complex panic")
+	st, ok := status.FromError(err)
+	assert.True(t, ok, "should be a gRPC status error")
+	assert.Equal(t, codes.Unknown, st.Code(), "should return Unknown code for complex panic")
+	// The exact message format may vary depending on how the map is stringified
+	assert.Contains(t, st.Message(), "panic triggered:", "should contain panic prefix")
+}
+
+// Test that the recovery option can be used with both unary and stream interceptors
+func TestRecoveryOptionCompatibility(t *testing.T) {
+	opt := RecoveryInterceptorOpt()
+
+	// Test that the option can be used with unary interceptor
+	unaryInterceptor := grpc_recovery.UnaryServerInterceptor(opt)
+	assert.NotNil(t, unaryInterceptor, "should create unary interceptor")
+
+	// Test that the option can be used with stream interceptor
+	streamInterceptor := grpc_recovery.StreamServerInterceptor(opt)
+	assert.NotNil(t, streamInterceptor, "should create stream interceptor")
+}
+
+// Test that the recovery handler preserves the panic value in the error message
+func TestRecoveryHandlerPreservesPanicValue(t *testing.T) {
+	opt := RecoveryInterceptorOpt()
+	unaryInterceptor := grpc_recovery.UnaryServerInterceptor(opt)
+
+	// Test with a custom error type
+	customError := errors.New("custom error message")
+	panicHandler := func(ctx context.Context, req any) (any, error) {
+		panic(customError)
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "test.Service/CustomErrorMethod",
+	}
+
+	resp, err := unaryInterceptor(context.Background(), "test request", info, panicHandler)
+
+	assert.Nil(t, resp, "should return nil response")
+	assert.Error(t, err, "should return error")
+	st, ok := status.FromError(err)
+	assert.True(t, ok, "should be a gRPC status error")
+	assert.Equal(t, codes.Unknown, st.Code(), "should return Unknown code")
+	assert.Equal(t, "panic triggered: custom error message", st.Message(), "should preserve custom error message")
+}

--- a/server/grpc/interceptor/trace.go
+++ b/server/grpc/interceptor/trace.go
@@ -3,7 +3,6 @@ package interceptor
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
@@ -26,11 +25,10 @@ func TracingUnaryServerInterceptor(serviceName string, serviceVersion string, OT
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		startTime := time.Now()
 
-		// Call the handler first
 		resp, err := handler(ctx, req)
 
 		// Only log if the decider allows it
-		if decideLogGRPCRequest(info.FullMethod, err) {
+		if ShouldLogFromContext(ctx) {
 			duration := time.Since(startTime)
 			code := errorsx.ConvertGRPCCode(err)
 			logGRPCRequest(
@@ -52,11 +50,10 @@ func TracingStreamServerInterceptor(serviceName string, serviceVersion string, O
 	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		startTime := time.Now()
 
-		// Call the handler first
 		err := handler(srv, stream)
 
 		// Only log if the decider allows it
-		if decideLogGRPCRequest(info.FullMethod, err) {
+		if ShouldLogFromContext(stream.Context()) {
 			duration := time.Since(startTime)
 			code := errorsx.ConvertGRPCCode(err)
 			logGRPCRequest(
@@ -71,19 +68,6 @@ func TracingStreamServerInterceptor(serviceName string, serviceVersion string, O
 
 		return err
 	}
-}
-
-// decideLogGRPCRequest determines if a gRPC request should be logged based on the full method name
-func decideLogGRPCRequest(fullMethod string, err error) bool {
-	if err == nil {
-		if match, _ := regexp.MatchString("model.model.v1alpha.ModelPublicService/.*ness$", fullMethod); match {
-			return false
-		} else if match, _ := regexp.MatchString("model.model.v1alpha.ModelPrivateService/.*Admin$", fullMethod); match {
-			return false
-		}
-	}
-	// by default everything will be logged
-	return true
 }
 
 // gRPCRequestLogOptions contains all the options for logging a gRPC request

--- a/server/grpc/interceptor/trace_test.go
+++ b/server/grpc/interceptor/trace_test.go
@@ -1,0 +1,478 @@
+package interceptor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	errorsx "github.com/instill-ai/x/errors"
+)
+
+func TestTracingUnaryServerInterceptor(t *testing.T) {
+	tests := []struct {
+		name                string
+		serviceName         string
+		serviceVersion      string
+		OTELCollectorEnable bool
+		fullMethod          string
+		shouldLog           bool
+		err                 error
+		expectedLogLevel    zapcore.Level
+		description         string
+	}{
+		{
+			name:                "successful request with logging enabled",
+			serviceName:         "test-service",
+			serviceVersion:      "v1.0.0",
+			OTELCollectorEnable: true,
+			fullMethod:          "test.Service/Method",
+			shouldLog:           true,
+			err:                 nil,
+			expectedLogLevel:    zapcore.InfoLevel,
+			description:         "should log at info level for successful request",
+		},
+		{
+			name:                "successful request with logging disabled",
+			serviceName:         "test-service",
+			serviceVersion:      "v1.0.0",
+			OTELCollectorEnable: false,
+			fullMethod:          "test.Service/Method",
+			shouldLog:           false,
+			err:                 nil,
+			expectedLogLevel:    zapcore.InfoLevel,
+			description:         "should not log when shouldLog is false",
+		},
+		{
+			name:                "request with warning error",
+			serviceName:         "test-service",
+			serviceVersion:      "v1.0.0",
+			OTELCollectorEnable: true,
+			fullMethod:          "test.Service/Method",
+			shouldLog:           true,
+			err:                 status.Error(codes.Canceled, "canceled"),
+			expectedLogLevel:    zapcore.WarnLevel,
+			description:         "should log at warn level for canceled error",
+		},
+		{
+			name:                "request with error",
+			serviceName:         "test-service",
+			serviceVersion:      "v1.0.0",
+			OTELCollectorEnable: true,
+			fullMethod:          "test.Service/Method",
+			shouldLog:           true,
+			err:                 status.Error(codes.InvalidArgument, "invalid argument"),
+			expectedLogLevel:    zapcore.ErrorLevel,
+			description:         "should log at error level for invalid argument error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create context with shouldLog flag
+			ctx := context.Background()
+			if !tt.shouldLog {
+				ctx = context.WithValue(ctx, shouldLogKey, false)
+			}
+
+			// Create mock logger
+			mockLogger := &MockLogger{}
+
+			// Create interceptor
+			interceptor := TracingUnaryServerInterceptor(tt.serviceName, tt.serviceVersion, tt.OTELCollectorEnable)
+
+			// Create request info
+			info := &grpc.UnaryServerInfo{
+				FullMethod: tt.fullMethod,
+			}
+
+			// Create handler that returns the specified error
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				return "response", tt.err
+			}
+
+			// Execute interceptor
+			resp, err := interceptor(ctx, "request", info, handler)
+
+			// Verify response and error
+			assert.Equal(t, "response", resp)
+			assert.Equal(t, tt.err, err)
+
+			// Verify logging behavior
+			if tt.shouldLog {
+				mockLogger.AssertExpectations(t)
+			} else {
+				mockLogger.AssertNotCalled(t, "Info")
+				mockLogger.AssertNotCalled(t, "Warn")
+				mockLogger.AssertNotCalled(t, "Error")
+			}
+		})
+	}
+}
+
+func TestTracingStreamServerInterceptor(t *testing.T) {
+	tests := []struct {
+		name                string
+		serviceName         string
+		serviceVersion      string
+		OTELCollectorEnable bool
+		fullMethod          string
+		shouldLog           bool
+		err                 error
+		expectedLogLevel    zapcore.Level
+		description         string
+	}{
+		{
+			name:                "successful stream with logging enabled",
+			serviceName:         "test-service",
+			serviceVersion:      "v1.0.0",
+			OTELCollectorEnable: true,
+			fullMethod:          "test.Service/StreamMethod",
+			shouldLog:           true,
+			err:                 nil,
+			expectedLogLevel:    zapcore.InfoLevel,
+			description:         "should log at info level for successful stream",
+		},
+		{
+			name:                "stream with logging disabled",
+			serviceName:         "test-service",
+			serviceVersion:      "v1.0.0",
+			OTELCollectorEnable: false,
+			fullMethod:          "test.Service/StreamMethod",
+			shouldLog:           false,
+			err:                 nil,
+			expectedLogLevel:    zapcore.InfoLevel,
+			description:         "should not log when shouldLog is false",
+		},
+		{
+			name:                "stream with error",
+			serviceName:         "test-service",
+			serviceVersion:      "v1.0.0",
+			OTELCollectorEnable: true,
+			fullMethod:          "test.Service/StreamMethod",
+			shouldLog:           true,
+			err:                 status.Error(codes.Internal, "internal error"),
+			expectedLogLevel:    zapcore.ErrorLevel,
+			description:         "should log at error level for internal error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create context with shouldLog flag
+			ctx := context.Background()
+			if !tt.shouldLog {
+				ctx = context.WithValue(ctx, shouldLogKey, false)
+			}
+
+			// Create mock stream
+			stream := &MockServerStream{ctx: ctx}
+
+			// Create mock logger
+			mockLogger := &MockLogger{}
+
+			// Create interceptor
+			interceptor := TracingStreamServerInterceptor(tt.serviceName, tt.serviceVersion, tt.OTELCollectorEnable)
+
+			// Create stream info
+			info := &grpc.StreamServerInfo{
+				FullMethod: tt.fullMethod,
+			}
+
+			// Create handler that returns the specified error
+			handler := func(srv interface{}, stream grpc.ServerStream) error {
+				return tt.err
+			}
+
+			// Execute interceptor
+			err := interceptor(nil, stream, info, handler)
+
+			// Verify error
+			assert.Equal(t, tt.err, err)
+
+			// Verify logging behavior
+			if tt.shouldLog {
+				mockLogger.AssertExpectations(t)
+			} else {
+				mockLogger.AssertNotCalled(t, "Info")
+				mockLogger.AssertNotCalled(t, "Warn")
+				mockLogger.AssertNotCalled(t, "Error")
+			}
+		})
+	}
+}
+
+func TestLogGRPCRequestOptions(t *testing.T) {
+	// Test withContext option
+	ctx := context.Background()
+	opts := &gRPCRequestLogOptions{}
+	withContext(ctx)(opts)
+	assert.Equal(t, ctx, opts.Context)
+
+	// Test withServiceInfo option
+	opts = &gRPCRequestLogOptions{}
+	withServiceInfo("test-service", "v1.0.0")(opts)
+	assert.Equal(t, "test-service", opts.ServiceName)
+	assert.Equal(t, "v1.0.0", opts.ServiceVersion)
+
+	// Test withMethodInfo option
+	opts = &gRPCRequestLogOptions{}
+	withMethodInfo("unary", "test.Service/Method")(opts)
+	assert.Equal(t, "unary", opts.MethodType)
+	assert.Equal(t, "test.Service/Method", opts.FullMethod)
+
+	// Test withTiming option
+	startTime := time.Now()
+	duration := time.Second
+	opts = &gRPCRequestLogOptions{}
+	withTiming(startTime, duration)(opts)
+	assert.Equal(t, startTime, opts.StartTime)
+	assert.Equal(t, duration, opts.Duration)
+
+	// Test withCode option
+	opts = &gRPCRequestLogOptions{}
+	withCode(codes.OK)(opts)
+	assert.Equal(t, codes.OK, opts.Code)
+
+	// Test withOTELEnable option
+	opts = &gRPCRequestLogOptions{}
+	withOTELEnable(true)(opts)
+	assert.True(t, opts.OTELCollectorEnable)
+}
+
+func TestMapZapLevelToOTELSeverity(t *testing.T) {
+	tests := []struct {
+		name         string
+		zapLevel     zapcore.Level
+		expectedOTEL log.Severity
+		description  string
+	}{
+		{
+			name:         "debug level",
+			zapLevel:     zapcore.DebugLevel,
+			expectedOTEL: log.SeverityDebug,
+			description:  "should map zap debug to OTEL debug",
+		},
+		{
+			name:         "info level",
+			zapLevel:     zapcore.InfoLevel,
+			expectedOTEL: log.SeverityInfo,
+			description:  "should map zap info to OTEL info",
+		},
+		{
+			name:         "warn level",
+			zapLevel:     zapcore.WarnLevel,
+			expectedOTEL: log.SeverityWarn,
+			description:  "should map zap warn to OTEL warn",
+		},
+		{
+			name:         "error level",
+			zapLevel:     zapcore.ErrorLevel,
+			expectedOTEL: log.SeverityError,
+			description:  "should map zap error to OTEL error",
+		},
+		{
+			name:         "unknown level defaults to info",
+			zapLevel:     zapcore.FatalLevel,
+			expectedOTEL: log.SeverityInfo,
+			description:  "should default to info for unknown levels",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mapZapLevelToOTELSeverity(tt.zapLevel)
+			assert.Equal(t, tt.expectedOTEL, result, tt.description)
+		})
+	}
+}
+
+func TestExtractMethodName(t *testing.T) {
+	tests := []struct {
+		name           string
+		fullMethod     string
+		expectedMethod string
+		description    string
+	}{
+		{
+			name:           "valid full method",
+			fullMethod:     "test.Service/SubService/Method", // This has 3 parts: ["test.Service", "SubService", "Method"]
+			expectedMethod: "Method",
+			description:    "should extract method name from valid full method",
+		},
+		{
+			name:           "full method with multiple slashes",
+			fullMethod:     "test.Service/SubService/Method",
+			expectedMethod: "Method",
+			description:    "should extract last part as method name",
+		},
+		{
+			name:           "invalid full method - too few parts",
+			fullMethod:     "test.Service",
+			expectedMethod: "unknown",
+			description:    "should return unknown for invalid full method",
+		},
+		{
+			name:           "empty full method",
+			fullMethod:     "",
+			expectedMethod: "unknown",
+			description:    "should return unknown for empty full method",
+		},
+		{
+			name:           "full method with trailing slash",
+			fullMethod:     "test.Service/Method/",
+			expectedMethod: "",
+			description:    "should handle trailing slash correctly",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractMethodName(tt.fullMethod)
+			assert.Equal(t, tt.expectedMethod, result, tt.description)
+		})
+	}
+}
+
+func TestConvertGRPCCode(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		expectedCode codes.Code
+		description  string
+	}{
+		{
+			name:         "nil error",
+			err:          nil,
+			expectedCode: codes.OK,
+			description:  "should return OK for nil error",
+		},
+		{
+			name:         "gRPC status error",
+			err:          status.Error(codes.InvalidArgument, "invalid argument"),
+			expectedCode: codes.InvalidArgument,
+			description:  "should return the gRPC status code",
+		},
+		{
+			name:         "non-gRPC error",
+			err:          assert.AnError,
+			expectedCode: codes.Unknown,
+			description:  "should return Unknown for non-gRPC errors",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := errorsx.ConvertGRPCCode(tt.err)
+			assert.Equal(t, tt.expectedCode, result, tt.description)
+		})
+	}
+}
+
+// Test log level determination based on gRPC codes
+func TestLogLevelDetermination(t *testing.T) {
+	tests := []struct {
+		name          string
+		code          codes.Code
+		expectedLevel zapcore.Level
+		description   string
+	}{
+		{
+			name:          "OK code",
+			code:          codes.OK,
+			expectedLevel: zapcore.InfoLevel,
+			description:   "should use info level for OK",
+		},
+		{
+			name:          "Canceled code",
+			code:          codes.Canceled,
+			expectedLevel: zapcore.WarnLevel,
+			description:   "should use warn level for Canceled",
+		},
+		{
+			name:          "InvalidArgument code",
+			code:          codes.InvalidArgument,
+			expectedLevel: zapcore.ErrorLevel,
+			description:   "should use error level for InvalidArgument",
+		},
+		{
+			name:          "Unknown code",
+			code:          codes.Unknown,
+			expectedLevel: zapcore.InfoLevel,
+			description:   "should default to info level for unknown codes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create options with the test code
+			opts := &gRPCRequestLogOptions{
+				Context: context.Background(),
+				Code:    tt.code,
+			}
+
+			// Determine log level (this logic is in logGRPCRequest)
+			var logLevel zapcore.Level
+			switch opts.Code {
+			case codes.OK:
+				logLevel = zapcore.InfoLevel
+			case codes.Canceled, codes.DeadlineExceeded, codes.PermissionDenied, codes.ResourceExhausted, codes.FailedPrecondition, codes.Aborted, codes.OutOfRange, codes.Unavailable, codes.DataLoss:
+				logLevel = zapcore.WarnLevel
+			case codes.InvalidArgument, codes.NotFound, codes.AlreadyExists, codes.Unimplemented, codes.Internal, codes.Unauthenticated:
+				logLevel = zapcore.ErrorLevel
+			default:
+				logLevel = zapcore.InfoLevel
+			}
+
+			assert.Equal(t, tt.expectedLevel, logLevel, tt.description)
+		})
+	}
+}
+
+// Test trace ID extraction
+func TestTraceIDExtraction(t *testing.T) {
+	// Create a context with a trace span
+	ctx := context.Background()
+	tracer := noop.NewTracerProvider().Tracer("test")
+	ctx, span := tracer.Start(ctx, "test-span")
+	defer span.End()
+
+	// Extract trace ID
+	traceID := trace.SpanFromContext(ctx).SpanContext().TraceID().String()
+
+	// Verify trace ID is not empty
+	assert.NotEmpty(t, traceID)
+	assert.Len(t, traceID, 32) // Trace ID should be 32 characters in hex
+}
+
+// Test message formatting
+func TestMessageFormatting(t *testing.T) {
+	ctx := context.Background()
+	tracer := noop.NewTracerProvider().Tracer("test")
+	ctx, span := tracer.Start(ctx, "test-span")
+	defer span.End()
+
+	methodType := "unary"
+	fullMethod := "test.Service/Method"
+
+	// Format message (this logic is in logGRPCRequest)
+	msg := fmt.Sprintf("finished %s call %s (trace_id: %s)",
+		methodType,
+		extractMethodName(fullMethod),
+		trace.SpanFromContext(ctx).SpanContext().TraceID().String(),
+	)
+
+	// Verify message format
+	assert.Contains(t, msg, "finished unary call unknown")
+	assert.Contains(t, msg, "trace_id:")
+	assert.Contains(t, msg, trace.SpanFromContext(ctx).SpanContext().TraceID().String())
+}

--- a/server/grpc/option.go
+++ b/server/grpc/option.go
@@ -17,10 +17,11 @@ import (
 
 // Options contains configuration options for gRPC server setup
 type Options struct {
-	ServiceName         string
-	ServiceVersion      string
-	HTTPSConfig         client.HTTPSConfig
-	OTELCollectorEnable bool
+	ServiceName           string
+	ServiceVersion        string
+	HTTPSConfig           client.HTTPSConfig
+	MethodExcludePatterns []string
+	OTELCollectorEnable   bool
 }
 
 // Option is a function that modifies Options
@@ -54,13 +55,21 @@ func WithServiceVersion(version string) Option {
 	}
 }
 
+// WithMethodExcludePatterns sets the methods to exclude from logging
+func WithMethodExcludePatterns(patterns []string) Option {
+	return func(opts *Options) {
+		opts.MethodExcludePatterns = patterns
+	}
+}
+
 // newGRPCOptions creates a new GRPCOptions with default values and applies the given options
 func newGRPCOptions(options ...Option) *Options {
 	opts := &Options{
-		ServiceName:         "unknown",
-		ServiceVersion:      "unknown",
-		HTTPSConfig:         client.HTTPSConfig{},
-		OTELCollectorEnable: false,
+		ServiceName:           "unknown",
+		ServiceVersion:        "unknown",
+		HTTPSConfig:           client.HTTPSConfig{},
+		MethodExcludePatterns: []string{},
+		OTELCollectorEnable:   false,
 	}
 
 	for _, option := range options {
@@ -77,11 +86,13 @@ func NewGRPCOptionAndCreds(options ...Option) ([]grpc.ServerOption, credentials.
 	grpcServerOpts := []grpc.ServerOption{
 		grpc.StreamInterceptor(grpcmiddleware.ChainStreamServer(
 			interceptor.StreamAppendMetadataInterceptor,
+			interceptor.DeciderStreamServerInterceptor(opts.MethodExcludePatterns),
 			interceptor.TracingStreamServerInterceptor(opts.ServiceName, opts.ServiceVersion, opts.OTELCollectorEnable),
 			grpcrecovery.StreamServerInterceptor(interceptor.RecoveryInterceptorOpt()),
 		)),
 		grpc.UnaryInterceptor(grpcmiddleware.ChainUnaryServer(
 			interceptor.UnaryAppendMetadataAndErrorCodeInterceptor,
+			interceptor.DeciderUnaryServerInterceptor(opts.MethodExcludePatterns),
 			interceptor.TracingUnaryServerInterceptor(opts.ServiceName, opts.ServiceVersion, opts.OTELCollectorEnable),
 			grpcrecovery.UnaryServerInterceptor(interceptor.RecoveryInterceptorOpt()),
 		)),


### PR DESCRIPTION
Because

- log decider should be an independent interceptor to be able to be configured.
 
This commit

- decouples the decider logic from tracing interceptor
- complete unit tests
- add documentation
