### PR TITLE
fix(acl): prefer user UID over auth type when resolving FGA subject

### DIFF
--- a/acl/README.md
+++ b/acl/README.md
@@ -69,8 +69,12 @@ err := client.SetOwner(ctx, "pipeline", pipelineUID, "user", userUID)
 ### List Permissions
 
 ```go
-// List all pipelines the current user can read
-pipelineUIDs, err := client.ListPermissions(ctx, "pipeline", "reader", false)
+// List all pipelines the current caller (authenticated user or
+// visitor, resolved from the request headers) can read.
+pipelineUIDs, err := client.ListPermissions(ctx, "pipeline", "reader")
+
+// List all pipelines that are publicly readable (FGA wildcard user:*).
+publicPipelineUIDs, err := client.ListPublicPermissions(ctx, "pipeline", "reader")
 ```
 
 ### Purge Permissions

--- a/acl/client.go
+++ b/acl/client.go
@@ -36,7 +36,10 @@ type Client interface {
 	// CheckPublicExecutable checks if an object has public execute permission.
 	CheckPublicExecutable(ctx context.Context, objectType string, objectUID uuid.UUID) (bool, error)
 	// ListPermissions lists all objects of a type that the current user has a role for.
-	ListPermissions(ctx context.Context, objectType string, role string, isPublic bool) ([]uuid.UUID, error)
+	ListPermissions(ctx context.Context, objectType string, role string) ([]uuid.UUID, error)
+	// ListPublicPermissions lists all objects of a type that are readable by
+	// everyone (tuples keyed to the FGA wildcard `user:*`).
+	ListPublicPermissions(ctx context.Context, objectType string, role string) ([]uuid.UUID, error)
 	// SetResourcePermission sets a permission for a user on any resource type.
 	SetResourcePermission(ctx context.Context, objectType string, objectUID uuid.UUID, user, role string, enable bool) error
 	// DeleteResourcePermission deletes all permissions for a user on a resource.
@@ -414,24 +417,83 @@ func (c *ACLClient) Purge(ctx context.Context, objectType string, objectUID uuid
 	return nil
 }
 
+// resolveACLSubject derives the OpenFGA subject (type, UID) from the
+// incoming request headers. Every ACL read path should funnel through
+// this helper so that the "who is asking?" decision is made in exactly
+// one place.
+//
+// Why this exists
+// ---------------
+// The earlier in-line logic selected the subject by branching on
+// `Instill-Auth-Type` alone:
+//
+//	if authType == "user" { uid = userUIDHeader } else { uid = visitorUIDHeader }
+//
+// That encodes an invariant that stopped holding once dual-auth (a
+// signed-in reader viewing a `/r/{token}` share link) became real:
+// the gateway stamps `Instill-Auth-Type: capability` together with a
+// non-empty `Instill-User-Uid` (and no visitor UID, because visitor
+// UIDs are only minted when the user UID is empty — see
+// api-gateway-ee's authenticateCapabilityToken). The else-branch then
+// read an empty visitor UID and every ACL check surfaced as
+// `unauthenticated: userUID is empty in check permission`, 401'ing
+// core flows such as `CreateChat` on `/r/{token}`.
+//
+// Selection rules
+// ---------------
+//  1. If `Instill-User-Uid` is non-empty, the caller is an
+//     authenticated user. The FGA subject is `user:{uuid}` regardless
+//     of `Instill-Auth-Type`, because all authenticated tuples in the
+//     store are keyed that way — emitting `capability:{uuid}` would
+//     never match a stored tuple and silently deny access.
+//
+//  2. Otherwise, if `Instill-Auth-Type` is a visitor-shaped label
+//     (`visitor` or `capability`) and `Instill-Visitor-Uid` is set,
+//     the caller is an anonymous visitor. The subject preserves the
+//     auth-type label (`visitor:{uuid}` / `capability:{uuid}`) so
+//     tuples written under those types keep resolving — visitor chat
+//     ownership, share_link userset expansion, etc.
+//
+//  3. Otherwise, no usable identity was found. Returning an error
+//     here preserves the long-standing "empty subject = unauthenticated"
+//     contract that callers rely on for 401 mapping.
+//
+// The returned `userType` is safe to use for both the FGA `User`
+// tuple field and the permission cache key without further munging.
+func resolveACLSubject(ctx context.Context) (userType, userUID string, err error) {
+	if uid := resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey); uid != "" {
+		// Rule (1): authenticated user. Always FGA-subject-type "user",
+		// even if the request also carries a capability/visitor label
+		// (dual-auth on a shared-link reader, etc.).
+		return "user", uid, nil
+	}
+
+	authType := resource.GetRequestSingleHeader(ctx, constant.HeaderAuthTypeKey)
+	switch authType {
+	case "visitor", "capability":
+		visitorUID := resource.GetRequestSingleHeader(ctx, constant.HeaderVisitorUIDKey)
+		if visitorUID == "" {
+			return "", "", fmt.Errorf("%w: userUID is empty in check permission", errorsx.ErrUnauthenticated)
+		}
+		// Rule (2): preserve the visitor/capability FGA subject type
+		// so existing tuples (e.g. visitor-owned chats, share_link
+		// tokens) keep resolving.
+		return authType, visitorUID, nil
+	}
+
+	// Rule (3): no recognizable identity header. The upstream "user"
+	// branch lost its user-UID header before reaching us (bug in the
+	// gateway or a mis-forwarded gRPC-to-gRPC hop) — fail closed.
+	return "", "", fmt.Errorf("%w: userUID is empty in check permission", errorsx.ErrUnauthenticated)
+}
+
 // CheckPermission verifies if the current user has a specific role for an object.
 func (c *ACLClient) CheckPermission(ctx context.Context, objectType string, objectUID uuid.UUID, role string) (bool, error) {
 	log, _ := logx.GetZapLogger(ctx)
 
-	// Retrieve the user type from the request context headers
-	userType := resource.GetRequestSingleHeader(ctx, constant.HeaderAuthTypeKey)
-	userUID := ""
-
-	// Determine the user UID based on the user type
-	if userType == "user" {
-		userUID = resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)
-	} else {
-		userUID = resource.GetRequestSingleHeader(ctx, constant.HeaderVisitorUIDKey)
-	}
-
-	// Check if the user UID is empty and return an error if it is
-	if userUID == "" {
-		return false, fmt.Errorf("%w: userUID is empty in check permission", errorsx.ErrUnauthenticated)
+	userType, userUID, err := resolveACLSubject(ctx)
+	if err != nil {
+		return false, err
 	}
 
 	// Determine whether to bypass caches and use HIGHER_CONSISTENCY.
@@ -582,22 +644,47 @@ func (c *ACLClient) IsUserPinned(ctx context.Context) bool {
 	return !errors.Is(c.redisClient.Get(ctx, pinKey).Err(), redis.Nil)
 }
 
-// ListPermissions lists all objects of a type that the current user has a role for.
-// Uses StreamedListObjects to avoid the 1000 result limit of the regular ListObjects API.
-func (c *ACLClient) ListPermissions(ctx context.Context, objectType string, role string, isPublic bool) ([]uuid.UUID, error) {
-	userType := resource.GetRequestSingleHeader(ctx, constant.HeaderAuthTypeKey)
-	userUIDStr := ""
-	if userType == "user" {
-		userUIDStr = resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)
-	} else {
-		userUIDStr = resource.GetRequestSingleHeader(ctx, constant.HeaderVisitorUIDKey)
+// ListPermissions lists all objects of a type that the current user
+// has the given role on. The caller's identity is resolved from the
+// request context via resolveACLSubject (authenticated user UID takes
+// precedence, with visitor/capability UIDs as the fallback).
+//
+// Use StreamedListObjects under the hood to avoid the 1000-result
+// limit of the regular ListObjects API, which matters for roles like
+// "reader" where a single user can be granted access to thousands of
+// objects.
+//
+// Callers that want to enumerate globally public objects (tuples keyed
+// to `user:*`) must use ListPublicPermissions instead; there is no
+// flag here because a wildcard listing has no caller identity and
+// conflating "list as me" with "list as anyone" has historically
+// produced subtle bugs (e.g. silently returning the public set when
+// the caller's identity failed to resolve).
+func (c *ACLClient) ListPermissions(ctx context.Context, objectType string, role string) ([]uuid.UUID, error) {
+	userType, userUIDStr, err := resolveACLSubject(ctx)
+	if err != nil {
+		return nil, err
 	}
+	return c.listObjectsForSubject(ctx, objectType, role, userType, userUIDStr)
+}
 
-	if isPublic {
-		userUIDStr = "*"
-	}
+// ListPublicPermissions lists all objects of a type that are readable
+// by everyone — i.e. tuples whose subject is the FGA wildcard
+// `user:*`. Separate from ListPermissions because the two have
+// incompatible authorisation semantics: a wildcard query has no
+// caller identity, must not return empty on an unauthenticated
+// request, and is never subject to the per-user read-after-write
+// pinning that ListPermissions honours.
+func (c *ACLClient) ListPublicPermissions(ctx context.Context, objectType string, role string) ([]uuid.UUID, error) {
+	return c.listObjectsForSubject(ctx, objectType, role, "user", "*")
+}
 
-	// Get the latest authorization model ID
+// listObjectsForSubject issues a StreamedListObjects call for the
+// given FGA subject. Factored out so ListPermissions (caller-scoped)
+// and ListPublicPermissions (wildcard) can share the streaming,
+// consistency, and error-translation logic without each growing its
+// own copy that then drifts.
+func (c *ACLClient) listObjectsForSubject(ctx context.Context, objectType, role, userType, userUIDStr string) ([]uuid.UUID, error) {
 	modelID, err := c.getAuthorizationModelID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting authorization model: %w", err)
@@ -612,9 +699,6 @@ func (c *ACLClient) ListPermissions(ctx context.Context, objectType string, role
 		consistency = openfga.ConsistencyPreference_HIGHER_CONSISTENCY
 	}
 
-	// Use StreamedListObjects to avoid the 1000 result limit of regular ListObjects.
-	// This streams all matching objects without pagination, which is essential when
-	// users have permissions for more than 1000 objects.
 	stream, err := c.getClient(ctx, ReadMode).StreamedListObjects(ctx, &openfga.StreamedListObjectsRequest{
 		StoreId:              c.storeID,
 		AuthorizationModelId: modelID,

--- a/acl/client_test.go
+++ b/acl/client_test.go
@@ -193,6 +193,31 @@ func visitorCtx(visitorUID string) context.Context {
 	})
 }
 
+// capabilityVisitorCtx models an anonymous visitor reading a
+// `/r/{token}` share link. The gateway stamps
+// Instill-Auth-Type=capability together with Instill-Visitor-Uid (no
+// user UID) — cap-token adds resource scope on top of the visitor
+// identity but does not itself authenticate anyone.
+func capabilityVisitorCtx(visitorUID string) context.Context {
+	return ctxWithHeaders(map[string]string{
+		constant.HeaderAuthTypeKey:   "capability",
+		constant.HeaderVisitorUIDKey: visitorUID,
+	})
+}
+
+// dualAuthCtx models an authenticated user who is also reading a
+// `/r/{token}` share link. The gateway stamps
+// Instill-Auth-Type=capability AND Instill-User-Uid (from the JWT)
+// AND does NOT set a visitor UID. This is the regression vector for
+// the dual-auth bug: the old selector branched on auth-type first and
+// silently dropped the user UID.
+func dualAuthCtx(userUID string) context.Context {
+	return ctxWithHeaders(map[string]string{
+		constant.HeaderAuthTypeKey: "capability",
+		constant.HeaderUserUIDKey:  userUID,
+	})
+}
+
 func orgDelegationCtx(userUID, orgUID string) context.Context {
 	return ctxWithHeaders(map[string]string{
 		constant.HeaderAuthTypeKey:     "user",
@@ -976,7 +1001,7 @@ func TestListPermissions_ReturnsObjectUIDs(t *testing.T) {
 	c := newTestClient(fga)
 	ctx := userCtx(testUserUID)
 
-	uids, err := c.ListPermissions(ctx, "pipeline", "reader", false)
+	uids, err := c.ListPermissions(ctx, "pipeline", "reader")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -985,7 +1010,14 @@ func TestListPermissions_ReturnsObjectUIDs(t *testing.T) {
 	}
 }
 
-func TestListPermissions_PublicUsesWildcard(t *testing.T) {
+// TestListPublicPermissions_UsesWildcardSubject pins the contract of
+// the dedicated public-listing method: it issues the FGA query with
+// the `user:*` wildcard subject, regardless of who (if anyone) the
+// caller is. The previous `ListPermissions(..., isPublic bool)` API
+// coupled this to a parameter flag and conflated unauthenticated
+// listings with public ones; the split makes the intent explicit at
+// the call site.
+func TestListPublicPermissions_UsesWildcardSubject(t *testing.T) {
 	fga := &mockFGA{
 		streamedListObjectsFn: func(_ context.Context, req *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
 			if req.User != "user:*" {
@@ -997,8 +1029,7 @@ func TestListPermissions_PublicUsesWildcard(t *testing.T) {
 	c := newTestClient(fga)
 	ctx := userCtx(testUserUID)
 
-	_, err := c.ListPermissions(ctx, "pipeline", "reader", true)
-	if err != nil {
+	if _, err := c.ListPublicPermissions(ctx, "pipeline", "reader"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -1016,7 +1047,7 @@ func TestListPermissions_VisitorUsesVisitorIdentity(t *testing.T) {
 	c := newTestClient(fga)
 	ctx := visitorCtx(testVisitorUID)
 
-	_, err := c.ListPermissions(ctx, "knowledgebase", "reader", false)
+	_, err := c.ListPermissions(ctx, "knowledgebase", "reader")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1036,7 +1067,7 @@ func TestListPermissions_RecvErrorMidStream(t *testing.T) {
 	c := newTestClient(fga)
 	ctx := userCtx(testUserUID)
 
-	_, err := c.ListPermissions(ctx, "pipeline", "reader", false)
+	_, err := c.ListPermissions(ctx, "pipeline", "reader")
 	if err == nil {
 		t.Fatal("error during stream receive should propagate")
 	}
@@ -1051,7 +1082,7 @@ func TestListPermissions_StreamErrorPropagated(t *testing.T) {
 	c := newTestClient(fga)
 	ctx := userCtx(testUserUID)
 
-	_, err := c.ListPermissions(ctx, "pipeline", "reader", false)
+	_, err := c.ListPermissions(ctx, "pipeline", "reader")
 	if err == nil {
 		t.Fatal("stream error should propagate so caller can retry")
 	}
@@ -1066,12 +1097,120 @@ func TestListPermissions_TypeNotFoundReturnsEmpty(t *testing.T) {
 	c := newTestClient(fga)
 	ctx := userCtx(testUserUID)
 
-	uids, err := c.ListPermissions(ctx, "nonexistent", "reader", false)
+	uids, err := c.ListPermissions(ctx, "nonexistent", "reader")
 	if err != nil {
 		t.Fatalf("type_not_found should return empty list, not error: %v", err)
 	}
 	if len(uids) != 0 {
 		t.Errorf("expected empty list, got %d items", len(uids))
+	}
+}
+
+// ============================================================
+// resolveACLSubject — dual-auth regression coverage
+// ============================================================
+//
+// These tests pin the behavioural contract of resolveACLSubject
+// through its two public callers (CheckPermission and
+// ListPermissions). The shared invariant is:
+//
+//	Instill-User-Uid, when present, wins over Instill-Auth-Type.
+//
+// That invariant used to be inverted — the selector keyed on auth
+// type first, so a request that legitimately carried BOTH a JWT and
+// an X-Capability-Token (the "logged-in user follows a /r/{token}
+// share link" flow) resolved to a capability subject with an empty
+// UID and was rejected as unauthenticated at the FGA layer.
+
+// TestCheckPermission_DualAuth_UsesUserSubject ensures that an
+// authenticated caller with an additional capability token is still
+// checked against FGA as `user:<uid>`. The cap-token only widens
+// which resources they may reach; it must not strip their identity.
+func TestCheckPermission_DualAuth_UsesUserSubject(t *testing.T) {
+	fga := &mockFGA{
+		checkFn: func(_ context.Context, req *openfga.CheckRequest) (*openfga.CheckResponse, error) {
+			want := fmt.Sprintf("user:%s", testUserUID)
+			if req.TupleKey.User != want {
+				t.Errorf("dual-auth must check as %s, got %s", want, req.TupleKey.User)
+			}
+			return &openfga.CheckResponse{Allowed: true}, nil
+		},
+	}
+	c := newTestClient(fga)
+	ctx := dualAuthCtx(testUserUID)
+
+	granted, err := c.CheckPermission(ctx, "pipeline", testObjectUID, "reader")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !granted {
+		t.Error("dual-auth user should be granted when FGA allows")
+	}
+}
+
+// TestCheckPermission_CapabilityVisitor_PreservesCapabilitySubject
+// covers the "unauthenticated visitor on a share link" flow. It must
+// keep resolving to `capability:<uid>` (not rewritten to
+// `visitor:<uid>`) because tuples for share-link ownership and cross
+// -workspace reads are written under the `capability` FGA user type
+// by the backend — rewriting the subject here would silently stop
+// matching those tuples and break share links for logged-out users.
+func TestCheckPermission_CapabilityVisitor_PreservesCapabilitySubject(t *testing.T) {
+	fga := &mockFGA{
+		checkFn: func(_ context.Context, req *openfga.CheckRequest) (*openfga.CheckResponse, error) {
+			want := fmt.Sprintf("capability:%s", testVisitorUID)
+			if req.TupleKey.User != want {
+				t.Errorf("capability visitor must check as %s, got %s", want, req.TupleKey.User)
+			}
+			return &openfga.CheckResponse{Allowed: true}, nil
+		},
+	}
+	c := newTestClient(fga)
+	ctx := capabilityVisitorCtx(testVisitorUID)
+
+	if _, err := c.CheckPermission(ctx, "pipeline", testObjectUID, "reader"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestCheckPermission_NoIdentity_Unauthenticated guards the negative
+// case: a context with neither a user UID nor a recognised
+// visitor/capability auth type must produce an explicit
+// unauthenticated error instead of silently querying FGA with an
+// empty subject (which historically returned "permission denied" and
+// hid the real problem).
+func TestCheckPermission_NoIdentity_Unauthenticated(t *testing.T) {
+	c := newTestClient(&mockFGA{})
+	ctx := ctxWithHeaders(map[string]string{})
+
+	_, err := c.CheckPermission(ctx, "pipeline", testObjectUID, "reader")
+	if err == nil {
+		t.Fatal("missing identity should surface as an error, not a silent deny")
+	}
+	if !errors.Is(err, errorsx.ErrUnauthenticated) {
+		t.Errorf("expected ErrUnauthenticated, got %v", err)
+	}
+}
+
+// TestListPermissions_DualAuth_UsesUserSubject mirrors the
+// CheckPermission dual-auth case for the streaming list API, since
+// both functions share resolveACLSubject and we want each public
+// entry point to have explicit regression coverage.
+func TestListPermissions_DualAuth_UsesUserSubject(t *testing.T) {
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, req *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			want := fmt.Sprintf("user:%s", testUserUID)
+			if req.User != want {
+				t.Errorf("dual-auth must list as %s, got %s", want, req.User)
+			}
+			return &mockStream{items: nil}, nil
+		},
+	}
+	c := newTestClient(fga)
+	ctx := dualAuthCtx(testUserUID)
+
+	if _, err := c.ListPermissions(ctx, "pipeline", "reader"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Because

- A signed-in reader following a `/r/{token}` share link arrives at the
  backend with both `Authorization: Bearer …` and `X-Capability-Token`.
  The gateway stamps `Instill-Auth-Type: capability` together with a
  non-empty `Instill-User-Uid`.
- `CheckPermission` and `ListPermissions` selected the FGA subject by
  branching on `Instill-Auth-Type` first, then reading the visitor UID
  header. For the dual-auth case the visitor UID is empty, so every
  cross-workspace read surfaced as `unauthenticated: userUID is empty
  in check permission` and 401'd flows like `CreateChat` on shared
  collections.
- The `isPublic` flag on `ListPermissions` conflated "list as me" with
  "list as anyone" in one signature. No caller in the monorepo passes
  `true`, and the branch silently masked unauthenticated requests as
  public.

This commit

- Introduce `resolveACLSubject` as the single source of truth for
  deriving the FGA subject from request headers, prioritising
  `Instill-User-Uid` over `Instill-Auth-Type` while preserving the
  `visitor:` and `capability:` subject types for anonymous callers.
- Route `CheckPermission` and `ListPermissions` through the new
  helper; emit an explicit `ErrUnauthenticated` when no identity is
  present instead of querying FGA with an empty subject.
- Split the public-listing path out as `ListPublicPermissions` and
  drop the `isPublic bool` parameter from `ListPermissions`; extract
  the shared streaming logic into `listObjectsForSubject`.
- Add regression tests for the dual-auth, capability-visitor, and
  no-identity cases on `CheckPermission` and `ListPermissions`, plus
  a wildcard-subject test for `ListPublicPermissions`.
- Update `acl/README.md` to show both listing entry points.