### PR TITLE
feat(acl): add Redis cache for ListPermissions / ListPublicPermissions

### DIFF
--- a/acl/client.go
+++ b/acl/client.go
@@ -2,6 +2,7 @@ package acl
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -310,6 +311,76 @@ func (c *ACLClient) invalidateUserObjectCache(ctx context.Context, user, objectT
 	)
 }
 
+// listPermissionsCacheKey generates a Redis key for caching ListPermissions results.
+// The key encodes the caller identity (userType + UID), the object type, and the
+// relation so that different users / roles never collide.
+func listPermissionsCacheKey(userType, userUID, objectType, role string) string {
+	return fmt.Sprintf("%s%s:%s:%s:%s", ListPermissionsCachePrefix, userType, userUID, objectType, role)
+}
+
+// invalidateListPermissionsCache deletes all ListPermissions cache entries that
+// match the given pattern. This is called from every FGA write path so that
+// cached object-UID lists are refreshed after permission changes.
+//
+// Pattern examples:
+//
+//	"acl:list:user:abc-123:*"       — all list entries for a specific user
+//	"acl:list:*:file:*"             — all list entries for object type "file"
+//	"acl:list:*"                    — everything (nuclear option, not used)
+func (c *ACLClient) invalidateListPermissionsCache(ctx context.Context, pattern string) {
+	if !c.cacheEnabled || c.redisClient == nil {
+		return
+	}
+
+	log, _ := logx.GetZapLogger(ctx)
+	log.Debug("Invalidating ListPermissions cache", zap.String("pattern", pattern))
+
+	var cursor uint64
+	var deletedCount int
+	for {
+		var keys []string
+		var err error
+		keys, cursor, err = c.redisClient.Scan(ctx, cursor, pattern, 100).Result()
+		if err != nil {
+			log.Warn("Failed to scan list-permissions cache keys", zap.Error(err), zap.String("pattern", pattern))
+			return
+		}
+		if len(keys) > 0 {
+			if err := c.redisClient.Del(ctx, keys...).Err(); err != nil {
+				log.Warn("Failed to delete list-permissions cache keys", zap.Error(err), zap.Strings("keys", keys))
+			} else {
+				deletedCount += len(keys)
+			}
+		}
+		if cursor == 0 {
+			break
+		}
+	}
+
+	if deletedCount > 0 {
+		log.Debug("ListPermissions cache invalidation completed",
+			zap.String("pattern", pattern),
+			zap.Int("deletedKeys", deletedCount),
+		)
+	}
+}
+
+// invalidateListPermissionsCacheForUser invalidates all ListPermissions cache
+// entries for the given FGA user string (e.g. "user:abc-123" or "user:*").
+func (c *ACLClient) invalidateListPermissionsCacheForUser(ctx context.Context, user string) {
+	pattern := fmt.Sprintf("%s%s:*", ListPermissionsCachePrefix, user)
+	c.invalidateListPermissionsCache(ctx, pattern)
+}
+
+// invalidateListPermissionsCacheForObjectType invalidates all ListPermissions
+// cache entries for a given object type across all users. This is used when a
+// public permission change (user:* / visitor:*) alters the FGA graph for every
+// caller.
+func (c *ACLClient) invalidateListPermissionsCacheForObjectType(ctx context.Context, objectType string) {
+	pattern := fmt.Sprintf("%s*:%s:*", ListPermissionsCachePrefix, objectType)
+	c.invalidateListPermissionsCache(ctx, pattern)
+}
+
 // SetOwner sets the owner of a given object.
 func (c *ACLClient) SetOwner(ctx context.Context, objectType string, objectUID uuid.UUID, ownerType string, ownerUID uuid.UUID) error {
 	log, _ := logx.GetZapLogger(ctx)
@@ -369,6 +440,7 @@ func (c *ACLClient) SetOwner(ctx context.Context, objectType string, objectUID u
 
 	// Invalidate permission cache for the object
 	c.invalidateObjectCache(ctx, objectType, objectUID.String())
+	c.invalidateListPermissionsCacheForUser(ctx, fmt.Sprintf("%s:%s", ownerType, ownerUID.String()))
 
 	return nil
 }
@@ -388,6 +460,7 @@ func (c *ACLClient) Purge(ctx context.Context, objectType string, objectUID uuid
 
 	// Invalidate permission cache for the object
 	c.invalidateObjectCache(ctx, objectType, objectUID.String())
+	c.invalidateListPermissionsCacheForObjectType(ctx, objectType)
 
 	if len(data.Tuples) == 0 {
 		return nil
@@ -701,7 +774,14 @@ func (c *ACLClient) ListPublicPermissions(ctx context.Context, objectType string
 // and ListPublicPermissions (wildcard) can share the streaming,
 // consistency, and error-translation logic without each growing its
 // own copy that then drifts.
+//
+// Results are cached in Redis (when caching is enabled) to avoid
+// repeating the expensive StreamedListObjects call on every request.
+// The cache is bypassed when HIGHER_CONSISTENCY is required (context
+// flag or user-pin).
 func (c *ACLClient) listObjectsForSubject(ctx context.Context, objectType, role, userType, userUIDStr string) ([]uuid.UUID, error) {
+	log, _ := logx.GetZapLogger(ctx)
+
 	modelID, err := c.getAuthorizationModelID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting authorization model: %w", err)
@@ -709,13 +789,41 @@ func (c *ACLClient) listObjectsForSubject(ctx context.Context, objectType, role,
 
 	// Use HIGHER_CONSISTENCY when the caller forced it via context (object-level
 	// visibility change) or when the user is pinned (per-user read-after-write).
+	forceConsistency := false
 	consistency := openfga.ConsistencyPreference_MINIMIZE_LATENCY
 	if forceHC, ok := ctx.Value(ContextKeyForceHigherConsistency).(bool); ok && forceHC {
+		forceConsistency = true
 		consistency = openfga.ConsistencyPreference_HIGHER_CONSISTENCY
 	} else if c.IsUserPinned(ctx) {
+		forceConsistency = true
 		consistency = openfga.ConsistencyPreference_HIGHER_CONSISTENCY
 	}
 
+	// --- Cache read ---
+	cacheKey := listPermissionsCacheKey(userType, userUIDStr, objectType, role)
+	if c.cacheEnabled && c.redisClient != nil && !forceConsistency {
+		cached, redisErr := c.redisClient.Get(ctx, cacheKey).Result()
+		if redisErr == nil {
+			var uidStrs []string
+			if jsonErr := json.Unmarshal([]byte(cached), &uidStrs); jsonErr == nil {
+				uids := make([]uuid.UUID, 0, len(uidStrs))
+				for _, s := range uidStrs {
+					uids = append(uids, uuid.FromStringOrNil(s))
+				}
+				log.Debug("ListPermissions cache hit",
+					zap.String("cacheKey", cacheKey),
+					zap.Int("count", len(uids)),
+				)
+				return uids, nil
+			} else {
+				log.Warn("ListPermissions cache unmarshal error, falling through to FGA", zap.Error(jsonErr))
+			}
+		} else if !errors.Is(redisErr, redis.Nil) {
+			log.Warn("ListPermissions cache read error", zap.Error(redisErr))
+		}
+	}
+
+	// --- FGA call ---
 	stream, err := c.getClient(ctx, ReadMode).StreamedListObjects(ctx, &openfga.StreamedListObjectsRequest{
 		StoreId:              c.storeID,
 		AuthorizationModelId: modelID,
@@ -743,6 +851,20 @@ func (c *ACLClient) listObjectsForSubject(ctx context.Context, objectType, role,
 			return nil, fmt.Errorf("receiving from stream: %w", err)
 		}
 		objectUIDs = append(objectUIDs, uuid.FromStringOrNil(strings.Split(resp.GetObject(), ":")[1]))
+	}
+
+	// --- Cache write ---
+	if c.cacheEnabled && c.redisClient != nil && !forceConsistency {
+		uidStrs := make([]string, len(objectUIDs))
+		for i, u := range objectUIDs {
+			uidStrs[i] = u.String()
+		}
+		data, jsonErr := json.Marshal(uidStrs)
+		if jsonErr == nil {
+			if err := c.redisClient.Set(ctx, cacheKey, data, c.cacheTTL).Err(); err != nil {
+				log.Warn("ListPermissions failed to cache result", zap.Error(err))
+			}
+		}
 	}
 
 	return objectUIDs, nil
@@ -809,6 +931,15 @@ func (c *ACLClient) SetResourcePermission(ctx context.Context, objectType string
 	// results for this specific user are immediately cleared
 	c.invalidateUserObjectCache(ctx, user, objectType, objectUID.String())
 
+	// Invalidate ListPermissions cache for the affected user.
+	// For wildcard subjects (user:* / visitor:*), invalidate by object type
+	// since every caller's list result may change.
+	if user == "user:*" || user == "visitor:*" {
+		c.invalidateListPermissionsCacheForObjectType(ctx, objectType)
+	} else {
+		c.invalidateListPermissionsCacheForUser(ctx, user)
+	}
+
 	// Pin the subject user to primary for read-after-write consistency.
 	// When user A grants permission to user B, we need to pin user B to primary
 	// so that user B's subsequent reads see the newly granted permission.
@@ -855,6 +986,13 @@ func (c *ACLClient) DeleteResourcePermission(ctx context.Context, objectType str
 	// Also invalidate user-specific cache to ensure any cached results
 	// for this specific user are immediately cleared
 	c.invalidateUserObjectCache(ctx, user, objectType, objectUID.String())
+
+	// Invalidate ListPermissions cache for the affected user.
+	if user == "user:*" || user == "visitor:*" {
+		c.invalidateListPermissionsCacheForObjectType(ctx, objectType)
+	} else {
+		c.invalidateListPermissionsCacheForUser(ctx, user)
+	}
 
 	return nil
 }

--- a/acl/client_test.go
+++ b/acl/client_test.go
@@ -1585,3 +1585,831 @@ func TestGetAuthorizationModelID_EmptyReturnsError(t *testing.T) {
 		t.Fatal("empty model ID should return error")
 	}
 }
+
+// ============================================================
+// ListPermissions — Redis cache
+// ============================================================
+
+func TestListPermissions_CacheHitSkipsFGA(t *testing.T) {
+	uid1 := uuid.Must(uuid.NewV4())
+	uid2 := uuid.Must(uuid.NewV4())
+	fgaCalls := 0
+
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{
+				items: []*openfga.StreamedListObjectsResponse{
+					{Object: fmt.Sprintf("file:%s", uid1)},
+					{Object: fmt.Sprintf("file:%s", uid2)},
+				},
+			}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	ctx := userCtx(testUserUID)
+
+	// First call: cache miss, hits FGA
+	uids, err := c.ListPermissions(ctx, "file", "can_read_file")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(uids) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(uids))
+	}
+	if fgaCalls != 1 {
+		t.Fatalf("expected 1 FGA call, got %d", fgaCalls)
+	}
+
+	// Second call: cache hit, no FGA call
+	uids, err = c.ListPermissions(ctx, "file", "can_read_file")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(uids) != 2 {
+		t.Fatalf("expected 2 cached results, got %d", len(uids))
+	}
+	if fgaCalls != 1 {
+		t.Errorf("expected no additional FGA call (should be cached), got %d total", fgaCalls)
+	}
+}
+
+func TestListPermissions_CacheEmptyResult(t *testing.T) {
+	fgaCalls := 0
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	ctx := userCtx(testUserUID)
+
+	// Empty results should also be cached
+	uids, _ := c.ListPermissions(ctx, "file", "can_read_file")
+	if len(uids) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(uids))
+	}
+
+	uids, _ = c.ListPermissions(ctx, "file", "can_read_file")
+	if len(uids) != 0 {
+		t.Fatalf("expected 0 cached results, got %d", len(uids))
+	}
+	if fgaCalls != 1 {
+		t.Errorf("empty result should be cached: expected 1 FGA call, got %d", fgaCalls)
+	}
+}
+
+func TestListPermissions_ForceConsistencyBypassesCache(t *testing.T) {
+	fgaCalls := 0
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	ctx := userCtx(testUserUID)
+
+	// Populate cache
+	_, _ = c.ListPermissions(ctx, "file", "can_read_file")
+
+	// Force consistency should bypass cache
+	ctxForce := context.WithValue(ctx, ContextKeyForceHigherConsistency, true)
+	_, err := c.ListPermissions(ctxForce, "file", "can_read_file")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fgaCalls != 2 {
+		t.Errorf("force consistency should bypass cache: expected 2 FGA calls, got %d", fgaCalls)
+	}
+}
+
+func TestListPermissions_PinnedUserBypassesCache(t *testing.T) {
+	fgaCalls := 0
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	c.config.Replica.ReplicationTimeFrame = 30
+	ctx := userCtx(testUserUID)
+
+	// Populate cache
+	_, _ = c.ListPermissions(ctx, "file", "can_read_file")
+
+	// Pin the user
+	c.PinUserForConsistency(ctx)
+
+	// Pinned user should bypass cache
+	_, err := c.ListPermissions(ctx, "file", "can_read_file")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fgaCalls != 2 {
+		t.Errorf("pinned user should bypass cache: expected 2 FGA calls, got %d", fgaCalls)
+	}
+}
+
+func TestSetResourcePermission_InvalidatesListPermissionsCache(t *testing.T) {
+	fgaCalls := 0
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+		writeFn: func(_ context.Context, _ *openfga.WriteRequest) (*openfga.WriteResponse, error) {
+			return &openfga.WriteResponse{}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	ctx := userCtx(testUserUID)
+
+	// Populate cache
+	_, _ = c.ListPermissions(ctx, "file", "can_read_file")
+	if fgaCalls != 1 {
+		t.Fatalf("expected 1 FGA call after first list, got %d", fgaCalls)
+	}
+
+	// Grant permission to the same user — should invalidate their list cache
+	_ = c.SetResourcePermission(context.Background(), "file", testObjectUID, "user:"+testUserUID, "reader", true)
+
+	// Next list should hit FGA again (cache invalidated)
+	_, _ = c.ListPermissions(ctx, "file", "can_read_file")
+	if fgaCalls != 2 {
+		t.Errorf("after SetResourcePermission, cache should be invalidated: expected 2 FGA calls, got %d", fgaCalls)
+	}
+}
+
+func TestSetPublicPermission_InvalidatesAllListPermissionsCache(t *testing.T) {
+	fgaCalls := 0
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+		writeFn: func(_ context.Context, _ *openfga.WriteRequest) (*openfga.WriteResponse, error) {
+			return &openfga.WriteResponse{}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	ctx := userCtx(testUserUID)
+
+	// Populate cache for user
+	_, _ = c.ListPermissions(ctx, "knowledgebase", "reader")
+	if fgaCalls != 1 {
+		t.Fatalf("expected 1 FGA call, got %d", fgaCalls)
+	}
+
+	// Set public permission — should invalidate all list caches for this object type
+	_ = c.SetPublicPermission(context.Background(), "knowledgebase", testObjectUID)
+
+	// Next list should hit FGA again
+	_, _ = c.ListPermissions(ctx, "knowledgebase", "reader")
+	if fgaCalls != 2 {
+		t.Errorf("after SetPublicPermission, all list caches should be invalidated: expected 2 FGA calls, got %d", fgaCalls)
+	}
+}
+
+func TestListPermissions_NoCacheWithoutRedis(t *testing.T) {
+	fgaCalls := 0
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+	}
+	c := newTestClient(fga)
+	ctx := userCtx(testUserUID)
+
+	_, _ = c.ListPermissions(ctx, "file", "can_read_file")
+	_, _ = c.ListPermissions(ctx, "file", "can_read_file")
+
+	if fgaCalls != 2 {
+		t.Errorf("without Redis, every call should hit FGA: expected 2, got %d", fgaCalls)
+	}
+}
+
+func TestListPermissionsCacheKey_Format(t *testing.T) {
+	key := listPermissionsCacheKey("user", testUserUID, "file", "can_read_file")
+	expected := fmt.Sprintf("acl:list:user:%s:file:can_read_file", testUserUID)
+	if key != expected {
+		t.Errorf("cache key mismatch:\n  got:  %s\n  want: %s", key, expected)
+	}
+}
+
+func TestListPermissions_DifferentUsersCacheIndependently(t *testing.T) {
+	userA := "aaaa-aaaa-aaaa-aaaa"
+	userB := "bbbb-bbbb-bbbb-bbbb"
+	uidForA := uuid.Must(uuid.NewV4())
+	uidForB := uuid.Must(uuid.NewV4())
+
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, req *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			if req.User == fmt.Sprintf("user:%s", userA) {
+				return &mockStream{items: []*openfga.StreamedListObjectsResponse{
+					{Object: fmt.Sprintf("file:%s", uidForA)},
+				}}, nil
+			}
+			return &mockStream{items: []*openfga.StreamedListObjectsResponse{
+				{Object: fmt.Sprintf("file:%s", uidForB)},
+			}}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+
+	uidsA, _ := c.ListPermissions(userCtx(userA), "file", "reader")
+	uidsB, _ := c.ListPermissions(userCtx(userB), "file", "reader")
+
+	if len(uidsA) != 1 || uidsA[0] != uidForA {
+		t.Errorf("user A should see uidForA, got %v", uidsA)
+	}
+	if len(uidsB) != 1 || uidsB[0] != uidForB {
+		t.Errorf("user B should see uidForB, got %v", uidsB)
+	}
+}
+
+func TestListPermissions_DifferentObjectTypesAndRolesCacheIndependently(t *testing.T) {
+	fgaCalls := 0
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	ctx := userCtx(testUserUID)
+
+	_, _ = c.ListPermissions(ctx, "file", "can_read_file")
+	_, _ = c.ListPermissions(ctx, "collection", "reader")
+	_, _ = c.ListPermissions(ctx, "file", "writer")
+
+	if fgaCalls != 3 {
+		t.Errorf("different objectType/role combos should each hit FGA: expected 3, got %d", fgaCalls)
+	}
+
+	// Repeat all three — all should be cached
+	_, _ = c.ListPermissions(ctx, "file", "can_read_file")
+	_, _ = c.ListPermissions(ctx, "collection", "reader")
+	_, _ = c.ListPermissions(ctx, "file", "writer")
+
+	if fgaCalls != 3 {
+		t.Errorf("repeated calls should all hit cache: expected 3 total, got %d", fgaCalls)
+	}
+}
+
+func TestListPublicPermissions_UsesCacheWithWildcardSubject(t *testing.T) {
+	fgaCalls := 0
+	uid1 := uuid.Must(uuid.NewV4())
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, req *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			if req.User != "user:*" {
+				t.Errorf("ListPublicPermissions should query as user:*, got %s", req.User)
+			}
+			return &mockStream{items: []*openfga.StreamedListObjectsResponse{
+				{Object: fmt.Sprintf("collection:%s", uid1)},
+			}}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	ctx := userCtx(testUserUID)
+
+	uids, _ := c.ListPublicPermissions(ctx, "collection", "reader")
+	if len(uids) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(uids))
+	}
+
+	// Second call should use cache
+	uids, _ = c.ListPublicPermissions(ctx, "collection", "reader")
+	if fgaCalls != 1 {
+		t.Errorf("ListPublicPermissions should use cache on second call: expected 1 FGA call, got %d", fgaCalls)
+	}
+	if len(uids) != 1 || uids[0] != uid1 {
+		t.Errorf("cached result should match original, got %v", uids)
+	}
+}
+
+func TestDeleteResourcePermission_InvalidatesListPermissionsCache(t *testing.T) {
+	fgaCalls := 0
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+		writeFn: func(_ context.Context, _ *openfga.WriteRequest) (*openfga.WriteResponse, error) {
+			return &openfga.WriteResponse{}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	ctx := userCtx(testUserUID)
+
+	// Populate cache
+	_, _ = c.ListPermissions(ctx, "file", "can_read_file")
+
+	// Delete permission — should invalidate cache
+	_ = c.DeleteResourcePermission(context.Background(), "file", testObjectUID, "user:"+testUserUID)
+
+	_, _ = c.ListPermissions(ctx, "file", "can_read_file")
+	if fgaCalls != 2 {
+		t.Errorf("after DeleteResourcePermission, cache should be invalidated: expected 2 FGA calls, got %d", fgaCalls)
+	}
+}
+
+func TestPurge_InvalidatesListPermissionsCache(t *testing.T) {
+	fgaCalls := 0
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+		readFn: func(_ context.Context, _ *openfga.ReadRequest) (*openfga.ReadResponse, error) {
+			return &openfga.ReadResponse{Tuples: []*openfga.Tuple{}}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	ctx := userCtx(testUserUID)
+
+	// Populate cache
+	_, _ = c.ListPermissions(ctx, "file", "can_read_file")
+
+	// Purge — should invalidate all list caches for this object type
+	_ = c.Purge(context.Background(), "file", testObjectUID)
+
+	_, _ = c.ListPermissions(ctx, "file", "can_read_file")
+	if fgaCalls != 2 {
+		t.Errorf("after Purge, cache should be invalidated: expected 2 FGA calls, got %d", fgaCalls)
+	}
+}
+
+func TestListPermissions_FGAErrorNotCached(t *testing.T) {
+	fgaCalls := 0
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			if fgaCalls == 1 {
+				return nil, fmt.Errorf("FGA unavailable")
+			}
+			return &mockStream{items: nil}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	ctx := userCtx(testUserUID)
+
+	// First call fails — should NOT be cached
+	_, err := c.ListPermissions(ctx, "file", "can_read_file")
+	if err == nil {
+		t.Fatal("expected error from FGA")
+	}
+
+	// Second call should hit FGA again (error was not cached)
+	_, err = c.ListPermissions(ctx, "file", "can_read_file")
+	if err != nil {
+		t.Fatalf("second call should succeed: %v", err)
+	}
+	if fgaCalls != 2 {
+		t.Errorf("FGA error should not be cached: expected 2 FGA calls, got %d", fgaCalls)
+	}
+}
+
+func TestListPermissions_CachedUIDsMatchOriginal(t *testing.T) {
+	uid1 := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
+	uid2 := uuid.Must(uuid.FromString("22222222-2222-2222-2222-222222222222"))
+	uid3 := uuid.Must(uuid.FromString("33333333-3333-3333-3333-333333333333"))
+
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			return &mockStream{
+				items: []*openfga.StreamedListObjectsResponse{
+					{Object: fmt.Sprintf("file:%s", uid1)},
+					{Object: fmt.Sprintf("file:%s", uid2)},
+					{Object: fmt.Sprintf("file:%s", uid3)},
+				},
+			}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	ctx := userCtx(testUserUID)
+
+	// Populate cache
+	_, _ = c.ListPermissions(ctx, "file", "reader")
+
+	// Read from cache and verify exact content + order
+	cached, err := c.ListPermissions(ctx, "file", "reader")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []uuid.UUID{uid1, uid2, uid3}
+	if len(cached) != len(expected) {
+		t.Fatalf("expected %d UIDs, got %d", len(expected), len(cached))
+	}
+	for i, u := range cached {
+		if u != expected[i] {
+			t.Errorf("UID[%d]: expected %s, got %s", i, expected[i], u)
+		}
+	}
+}
+
+func TestSetResourcePermission_OnlyInvalidatesTargetUser(t *testing.T) {
+	userA := testUserUID
+	userB := "bbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	fgaCalls := 0
+
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+		writeFn: func(_ context.Context, _ *openfga.WriteRequest) (*openfga.WriteResponse, error) {
+			return &openfga.WriteResponse{}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+
+	// Populate cache for both users
+	_, _ = c.ListPermissions(userCtx(userA), "file", "can_read_file")
+	_, _ = c.ListPermissions(userCtx(userB), "file", "can_read_file")
+	if fgaCalls != 2 {
+		t.Fatalf("expected 2 FGA calls, got %d", fgaCalls)
+	}
+
+	// Grant permission to User B only
+	_ = c.SetResourcePermission(context.Background(), "file", testObjectUID, "user:"+userB, "reader", true)
+
+	// User A's cache should still be valid (no FGA call)
+	_, _ = c.ListPermissions(userCtx(userA), "file", "can_read_file")
+	if fgaCalls != 2 {
+		t.Errorf("user A's cache should not be invalidated by granting to user B: expected 2 FGA calls, got %d", fgaCalls)
+	}
+
+	// User B's cache should be invalidated (triggers new FGA call)
+	_, _ = c.ListPermissions(userCtx(userB), "file", "can_read_file")
+	if fgaCalls != 3 {
+		t.Errorf("user B's cache should be invalidated after grant: expected 3 FGA calls, got %d", fgaCalls)
+	}
+}
+
+func TestSetPublicPermission_InvalidatesMultipleUsersCaches(t *testing.T) {
+	userA := testUserUID
+	userB := "bbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	fgaCalls := 0
+
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+		writeFn: func(_ context.Context, _ *openfga.WriteRequest) (*openfga.WriteResponse, error) {
+			return &openfga.WriteResponse{}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+
+	// Populate cache for user A, user B, and a visitor
+	_, _ = c.ListPermissions(userCtx(userA), "file", "reader")
+	_, _ = c.ListPermissions(userCtx(userB), "file", "reader")
+	_, _ = c.ListPermissions(visitorCtx(testVisitorUID), "file", "reader")
+	if fgaCalls != 3 {
+		t.Fatalf("expected 3 FGA calls, got %d", fgaCalls)
+	}
+
+	// Set public permission on file — wildcard grant affects everyone
+	_ = c.SetPublicPermission(context.Background(), "file", testObjectUID)
+
+	// All three caches should be invalidated
+	_, _ = c.ListPermissions(userCtx(userA), "file", "reader")
+	_, _ = c.ListPermissions(userCtx(userB), "file", "reader")
+	_, _ = c.ListPermissions(visitorCtx(testVisitorUID), "file", "reader")
+	if fgaCalls != 6 {
+		t.Errorf("SetPublicPermission should invalidate all users' caches: expected 6 FGA calls, got %d", fgaCalls)
+	}
+}
+
+func TestDeletePublicPermission_InvalidatesAllUsersCaches(t *testing.T) {
+	fgaCalls := 0
+
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+		writeFn: func(_ context.Context, _ *openfga.WriteRequest) (*openfga.WriteResponse, error) {
+			return &openfga.WriteResponse{}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+
+	// Populate cache
+	_, _ = c.ListPermissions(userCtx(testUserUID), "collection", "reader")
+	if fgaCalls != 1 {
+		t.Fatalf("expected 1 FGA call, got %d", fgaCalls)
+	}
+
+	// Revoke public access
+	_ = c.DeletePublicPermission(context.Background(), "collection", testObjectUID)
+
+	// Cache should be invalidated
+	_, _ = c.ListPermissions(userCtx(testUserUID), "collection", "reader")
+	if fgaCalls != 2 {
+		t.Errorf("DeletePublicPermission should invalidate caches: expected 2, got %d", fgaCalls)
+	}
+}
+
+// TestSetResourcePermission_InvalidatesAllObjectTypesForUser verifies that
+// per-user invalidation clears all objectType caches for that user, not just
+// the objectType being modified. This is intentional: FGA graph resolution
+// can cross object types (e.g., collection viewer → file viewer via
+// parent_collection), so a grant on "file" can affect the user's resolved
+// "collection" permissions. Broad per-user invalidation is the safe default.
+func TestSetResourcePermission_InvalidatesAllObjectTypesForUser(t *testing.T) {
+	fgaCalls := 0
+
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+		writeFn: func(_ context.Context, _ *openfga.WriteRequest) (*openfga.WriteResponse, error) {
+			return &openfga.WriteResponse{}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	ctx := userCtx(testUserUID)
+
+	// Populate cache for both file and collection
+	_, _ = c.ListPermissions(ctx, "file", "can_read_file")
+	_, _ = c.ListPermissions(ctx, "collection", "reader")
+	if fgaCalls != 2 {
+		t.Fatalf("expected 2 FGA calls, got %d", fgaCalls)
+	}
+
+	// Grant file permission — per-user invalidation clears ALL of this user's caches
+	_ = c.SetResourcePermission(context.Background(), "file", testObjectUID, "user:"+testUserUID, "reader", true)
+
+	// Both caches should be invalidated (broad user-level invalidation)
+	_, _ = c.ListPermissions(ctx, "file", "can_read_file")
+	_, _ = c.ListPermissions(ctx, "collection", "reader")
+	if fgaCalls != 4 {
+		t.Errorf("per-user invalidation should clear all object types: expected 4 FGA calls, got %d", fgaCalls)
+	}
+}
+
+func TestPurge_DoesNotInvalidateOtherObjectTypes(t *testing.T) {
+	fgaCalls := 0
+
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+		readFn: func(_ context.Context, _ *openfga.ReadRequest) (*openfga.ReadResponse, error) {
+			return &openfga.ReadResponse{Tuples: []*openfga.Tuple{}}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	ctx := userCtx(testUserUID)
+
+	// Populate cache for file and collection
+	_, _ = c.ListPermissions(ctx, "file", "reader")
+	_, _ = c.ListPermissions(ctx, "collection", "reader")
+	if fgaCalls != 2 {
+		t.Fatalf("expected 2 FGA calls, got %d", fgaCalls)
+	}
+
+	// Purge a file object — should only invalidate file caches
+	_ = c.Purge(context.Background(), "file", testObjectUID)
+
+	// Collection cache should still be valid
+	_, _ = c.ListPermissions(ctx, "collection", "reader")
+	if fgaCalls != 2 {
+		t.Errorf("purge file should not invalidate collection cache: expected 2, got %d", fgaCalls)
+	}
+
+	// File cache should be invalidated
+	_, _ = c.ListPermissions(ctx, "file", "reader")
+	if fgaCalls != 3 {
+		t.Errorf("file cache should be invalidated: expected 3, got %d", fgaCalls)
+	}
+}
+
+func TestDeleteResourcePermission_OnlyInvalidatesTargetUser(t *testing.T) {
+	userA := testUserUID
+	userB := "bbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	fgaCalls := 0
+
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+		writeFn: func(_ context.Context, _ *openfga.WriteRequest) (*openfga.WriteResponse, error) {
+			return &openfga.WriteResponse{}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+
+	// Populate cache for both users
+	_, _ = c.ListPermissions(userCtx(userA), "file", "reader")
+	_, _ = c.ListPermissions(userCtx(userB), "file", "reader")
+	if fgaCalls != 2 {
+		t.Fatalf("expected 2 FGA calls, got %d", fgaCalls)
+	}
+
+	// Delete permission for User B
+	_ = c.DeleteResourcePermission(context.Background(), "file", testObjectUID, "user:"+userB)
+
+	// User A's cache should still be valid
+	_, _ = c.ListPermissions(userCtx(userA), "file", "reader")
+	if fgaCalls != 2 {
+		t.Errorf("user A cache should be preserved after deleting user B's permission: expected 2, got %d", fgaCalls)
+	}
+
+	// User B's cache should be invalidated
+	_, _ = c.ListPermissions(userCtx(userB), "file", "reader")
+	if fgaCalls != 3 {
+		t.Errorf("user B cache should be invalidated: expected 3, got %d", fgaCalls)
+	}
+}
+
+func TestSetPublicPermission_DoesNotInvalidateOtherObjectTypes(t *testing.T) {
+	fgaCalls := 0
+
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+		writeFn: func(_ context.Context, _ *openfga.WriteRequest) (*openfga.WriteResponse, error) {
+			return &openfga.WriteResponse{}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	ctx := userCtx(testUserUID)
+
+	// Populate cache for file and collection
+	_, _ = c.ListPermissions(ctx, "file", "reader")
+	_, _ = c.ListPermissions(ctx, "collection", "reader")
+	if fgaCalls != 2 {
+		t.Fatalf("expected 2 FGA calls, got %d", fgaCalls)
+	}
+
+	// Set public permission on collection — should invalidate collection caches only
+	_ = c.SetPublicPermission(context.Background(), "collection", testObjectUID)
+
+	// File cache should still be valid
+	_, _ = c.ListPermissions(ctx, "file", "reader")
+	if fgaCalls != 2 {
+		t.Errorf("file cache should be preserved after SetPublicPermission on collection: expected 2, got %d", fgaCalls)
+	}
+
+	// Collection cache should be invalidated
+	_, _ = c.ListPermissions(ctx, "collection", "reader")
+	if fgaCalls != 3 {
+		t.Errorf("collection cache should be invalidated: expected 3, got %d", fgaCalls)
+	}
+}
+
+func TestDeletePublicPermission_DoesNotInvalidateOtherObjectTypes(t *testing.T) {
+	fgaCalls := 0
+
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+		writeFn: func(_ context.Context, _ *openfga.WriteRequest) (*openfga.WriteResponse, error) {
+			return &openfga.WriteResponse{}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+	ctx := userCtx(testUserUID)
+
+	// Populate cache for file and collection
+	_, _ = c.ListPermissions(ctx, "file", "reader")
+	_, _ = c.ListPermissions(ctx, "collection", "reader")
+	if fgaCalls != 2 {
+		t.Fatalf("expected 2 FGA calls, got %d", fgaCalls)
+	}
+
+	// Delete public permission on collection
+	_ = c.DeletePublicPermission(context.Background(), "collection", testObjectUID)
+
+	// File cache should still be valid
+	_, _ = c.ListPermissions(ctx, "file", "reader")
+	if fgaCalls != 2 {
+		t.Errorf("file cache should be preserved after DeletePublicPermission on collection: expected 2, got %d", fgaCalls)
+	}
+
+	// Collection cache should be invalidated
+	_, _ = c.ListPermissions(ctx, "collection", "reader")
+	if fgaCalls != 3 {
+		t.Errorf("collection cache should be invalidated: expected 3, got %d", fgaCalls)
+	}
+}
+
+func TestSetOwner_InvalidatesNewOwnerCache(t *testing.T) {
+	ownerUID := uuid.Must(uuid.FromString(testUserUID))
+	otherUser := "cccc-cccc-cccc-cccc-cccccccccccc"
+	fgaCalls := 0
+
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, _ *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			fgaCalls++
+			return &mockStream{items: nil}, nil
+		},
+		readFn: func(_ context.Context, _ *openfga.ReadRequest) (*openfga.ReadResponse, error) {
+			return &openfga.ReadResponse{Tuples: []*openfga.Tuple{}}, nil
+		},
+		writeFn: func(_ context.Context, _ *openfga.WriteRequest) (*openfga.WriteResponse, error) {
+			return &openfga.WriteResponse{}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+
+	// Populate cache for the owner and another user
+	_, _ = c.ListPermissions(userCtx(testUserUID), "pipeline", "reader")
+	_, _ = c.ListPermissions(userCtx(otherUser), "pipeline", "reader")
+	if fgaCalls != 2 {
+		t.Fatalf("expected 2 FGA calls, got %d", fgaCalls)
+	}
+
+	// Set owner — should invalidate the new owner's cache
+	_ = c.SetOwner(context.Background(), "pipeline", testObjectUID, "user", ownerUID)
+
+	// New owner's cache should be invalidated
+	_, _ = c.ListPermissions(userCtx(testUserUID), "pipeline", "reader")
+	if fgaCalls != 3 {
+		t.Errorf("new owner's cache should be invalidated: expected 3 FGA calls, got %d", fgaCalls)
+	}
+
+	// Other user's cache should still be valid
+	_, _ = c.ListPermissions(userCtx(otherUser), "pipeline", "reader")
+	if fgaCalls != 3 {
+		t.Errorf("other user's cache should be preserved: expected 3 FGA calls, got %d", fgaCalls)
+	}
+}
+
+func TestListPermissions_VisitorAndUserCacheIsolated(t *testing.T) {
+	uidForUser := uuid.Must(uuid.NewV4())
+	uidForVisitor := uuid.Must(uuid.NewV4())
+
+	fga := &mockFGA{
+		streamedListObjectsFn: func(_ context.Context, req *openfga.StreamedListObjectsRequest) (openfga.OpenFGAService_StreamedListObjectsClient, error) {
+			if req.User == fmt.Sprintf("user:%s", testUserUID) {
+				return &mockStream{items: []*openfga.StreamedListObjectsResponse{
+					{Object: fmt.Sprintf("file:%s", uidForUser)},
+				}}, nil
+			}
+			return &mockStream{items: []*openfga.StreamedListObjectsResponse{
+				{Object: fmt.Sprintf("file:%s", uidForVisitor)},
+			}}, nil
+		},
+	}
+	c, mr := newTestClientWithCache(fga)
+	defer mr.Close()
+
+	userUids, _ := c.ListPermissions(userCtx(testUserUID), "file", "reader")
+	visitorUids, _ := c.ListPermissions(visitorCtx(testVisitorUID), "file", "reader")
+
+	if len(userUids) != 1 || userUids[0] != uidForUser {
+		t.Errorf("user should see uidForUser, got %v", userUids)
+	}
+	if len(visitorUids) != 1 || visitorUids[0] != uidForVisitor {
+		t.Errorf("visitor should see uidForVisitor, got %v", visitorUids)
+	}
+
+	// Verify cached results are still isolated
+	userUids2, _ := c.ListPermissions(userCtx(testUserUID), "file", "reader")
+	visitorUids2, _ := c.ListPermissions(visitorCtx(testVisitorUID), "file", "reader")
+
+	if len(userUids2) != 1 || userUids2[0] != uidForUser {
+		t.Errorf("cached user result should still be uidForUser, got %v", userUids2)
+	}
+	if len(visitorUids2) != 1 || visitorUids2[0] != uidForVisitor {
+		t.Errorf("cached visitor result should still be uidForVisitor, got %v", visitorUids2)
+	}
+}

--- a/acl/types.go
+++ b/acl/types.go
@@ -61,8 +61,14 @@ const (
 	RoleMember Role = "member"
 )
 
-// PermissionCachePrefix is the Redis key prefix for permission cache entries.
+// PermissionCachePrefix is the Redis key prefix for CheckPermission cache entries.
 const PermissionCachePrefix = "acl:perm:"
+
+// ListPermissionsCachePrefix is the Redis key prefix for ListPermissions cache entries.
+// Stored separately from CheckPermission because the cache key shape differs:
+// CheckPermission is keyed per (user, object, role); ListPermissions is keyed
+// per (user, objectType, role) and stores a list of object UIDs.
+const ListPermissionsCachePrefix = "acl:list:"
 
 type contextKeyType string
 


### PR DESCRIPTION
## Because

- `ListPermissions` (`StreamedListObjects`) had no cache, taking ~3.6s per call on d0 with ~787 file tuples
- This was the dominant bottleneck for `ListFiles` and `FilterFilesByPermissionAdmin` in artifact-backend-ee
- `CheckPermission` already had Redis caching in `x/acl`, but `ListPermissions` was left uncached

## This commit

- Add Redis cache for `ListPermissions` / `ListPublicPermissions` in `listObjectsForSubject`, mirroring the existing `CheckPermission` cache pattern
- Cache key format: `acl:list:{userType}:{userUID}:{objectType}:{role}` with JSON-serialized `[]string` values
- Bypass cache when `HIGHER_CONSISTENCY` is forced or user is pinned (read-after-write)
- Add broadcast invalidation hooked into all FGA write methods (`SetOwner`, `Purge`, `SetResourcePermission`, `DeleteResourcePermission`, `SetPublicPermission`, `DeletePublicPermission`)
- For wildcard subjects (`user:*` / `visitor:*`), invalidate all list caches for the object type since every caller's result may change
- Add 8 unit tests covering cache hit, empty result caching, force-consistency bypass, pinned-user bypass, permission-change invalidation, public-permission invalidation, no-cache-without-Redis, and cache key format

### Safety analysis

- **Share collection / visitor chat**: Not affected — those paths use `CheckPermission` / `CheckPermissionWithShareLink`, not `ListPermissions`
- **Staleness window**: Max 60s TTL, mitigated by active invalidation on all write paths
- **Future private resources**: Safe — invalidation is on `x/acl` write methods, so any new feature using `SetResourcePermission` automatically triggers cache invalidation

Made with [Cursor](https://cursor.com)