### PR TITLE
fix(client/grpc): add periodic DNS re-resolution resolver for HPA pod discovery

### DIFF
--- a/acl/client.go
+++ b/acl/client.go
@@ -18,6 +18,8 @@ import (
 	"google.golang.org/grpc/status"
 
 	openfga "github.com/openfga/api/proto/openfga/v1"
+
+	xgrpc "github.com/instill-ai/x/client/grpc"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/instill-ai/x/constant"
@@ -162,8 +164,9 @@ func InitOpenFGAClient(ctx context.Context, host string, port int, maxDataSize i
 
 	const MB = 1024 * 1024
 	clientConn, err := grpc.NewClient(
-		fmt.Sprintf("dns:///%v:%v", host, port),
+		fmt.Sprintf("%s:///%v:%v", xgrpc.DNSRefreshScheme, host, port),
 		clientDialOpts,
+		grpc.WithResolvers(xgrpc.PeriodicDNSResolverBuilder(xgrpc.DefaultDNSRefreshInterval)),
 		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig":[{"round_robin":{}}]}`),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(maxDataSize*MB),

--- a/acl/client_grpc_test.go
+++ b/acl/client_grpc_test.go
@@ -11,7 +11,7 @@ func TestInitOpenFGAClient_DNSTarget(t *testing.T) {
 	defer func() { _ = conn.Close() }()
 
 	target := conn.Target()
-	if !strings.HasPrefix(target, "dns:///") {
-		t.Fatalf("expected dns:/// prefix, got target=%q", target)
+	if !strings.HasPrefix(target, "dns-refresh:///") {
+		t.Fatalf("expected dns-refresh:/// prefix, got target=%q", target)
 	}
 }

--- a/client/grpc/clients.go
+++ b/client/grpc/clients.go
@@ -181,11 +181,12 @@ func newConn(host string, port int, opts *Options) (conn *grpc.ClientConn, err e
 
 	dialOpts = append(dialOpts, grpc.WithDefaultServiceConfig(roundRobinSvcConfig))
 
-	// dns:/// resolver enables gRPC-native DNS resolution which returns all
-	// A records (pod IPs behind a headless K8s Service). Combined with
-	// round_robin above, RPCs are distributed across every ready pod instead
-	// of being pinned to whichever pod kube-proxy picked at connect time.
-	target := fmt.Sprintf("dns:///%s:%d", host, port)
+	// dns-refresh:/// resolver periodically re-resolves DNS A records so that
+	// newly HPA-scaled pods behind a headless K8s Service are discovered within
+	// one refresh cycle. The built-in dns:/// resolver only re-resolves on
+	// subchannel failure, so pods added after the initial dial are invisible.
+	dialOpts = append(dialOpts, grpc.WithResolvers(PeriodicDNSResolverBuilder(DefaultDNSRefreshInterval)))
+	target := fmt.Sprintf("%s:///%s:%d", DNSRefreshScheme, host, port)
 
 	conn, err = grpc.NewClient(target, dialOpts...)
 	if err != nil {

--- a/client/grpc/clients_test.go
+++ b/client/grpc/clients_test.go
@@ -640,7 +640,7 @@ func TestNewConn_UsesDNSResolverAndRoundRobin(t *testing.T) {
 	defer func() { _ = conn.Close() }()
 
 	target := conn.Target()
-	qt.Check(target, quicktest.Equals, "dns:///my-service-headless:8080")
+	qt.Check(target, quicktest.Equals, DNSRefreshScheme+":///my-service-headless:8080")
 }
 
 func TestNewClient_OptionsPattern(t *testing.T) {

--- a/client/grpc/resolver.go
+++ b/client/grpc/resolver.go
@@ -1,0 +1,133 @@
+package grpc
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/resolver"
+)
+
+const (
+	// DefaultDNSRefreshInterval is the interval at which the periodic DNS
+	// resolver re-resolves hostnames. The gRPC built-in DNS resolver only
+	// re-resolves on subchannel failure; when HPA adds new pods behind a
+	// headless K8s service the existing client never discovers them. This
+	// resolver periodically looks up DNS A records and pushes updated
+	// addresses to the balancer, so round_robin distributes RPCs across
+	// newly scaled pods within one refresh cycle.
+	DefaultDNSRefreshInterval = 30 * time.Second
+)
+
+// DNSRefreshScheme is the resolver scheme for the periodic DNS resolver.
+const DNSRefreshScheme = "dns-refresh"
+
+// PeriodicDNSResolverBuilder returns a resolver.Builder that periodically
+// re-resolves DNS A records for the target host and pushes updated
+// addresses to the gRPC balancer.
+//
+// Usage:
+//
+//	grpc.NewClient("dns-refresh:///my-headless-svc:8091",
+//	    grpc.WithResolvers(xgrpc.PeriodicDNSResolverBuilder(30*time.Second)),
+//	    grpc.WithDefaultServiceConfig(`{"loadBalancingConfig":[{"round_robin":{}}]}`),
+//	)
+func PeriodicDNSResolverBuilder(interval time.Duration) resolver.Builder {
+	if interval <= 0 {
+		interval = DefaultDNSRefreshInterval
+	}
+	return &periodicDNSBuilder{interval: interval}
+}
+
+type periodicDNSBuilder struct {
+	interval time.Duration
+}
+
+func (b *periodicDNSBuilder) Scheme() string { return DNSRefreshScheme }
+
+func (b *periodicDNSBuilder) Build(target resolver.Target, cc resolver.ClientConn, _ resolver.BuildOptions) (resolver.Resolver, error) {
+	host, port, err := parseHostPort(target.Endpoint())
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &periodicDNSResolver{
+		host:     host,
+		port:     port,
+		cc:       cc,
+		interval: b.interval,
+		ctx:      ctx,
+		cancel:   cancel,
+		netRes:   net.DefaultResolver,
+	}
+
+	r.resolve()
+	go r.loop()
+	return r, nil
+}
+
+type periodicDNSResolver struct {
+	host     string
+	port     string
+	cc       resolver.ClientConn
+	interval time.Duration
+	ctx      context.Context
+	cancel   context.CancelFunc
+	closeOnce sync.Once
+	netRes   *net.Resolver
+}
+
+func (r *periodicDNSResolver) resolve() {
+	lookupCtx, lookupCancel := context.WithTimeout(r.ctx, 5*time.Second)
+	defer lookupCancel()
+
+	addrs, err := r.netRes.LookupHost(lookupCtx, r.host)
+	if err != nil {
+		r.cc.ReportError(err)
+		return
+	}
+
+	var endpoints []resolver.Address
+	for _, a := range addrs {
+		endpoints = append(endpoints, resolver.Address{Addr: net.JoinHostPort(a, r.port)})
+	}
+	if len(endpoints) > 0 {
+		_ = r.cc.UpdateState(resolver.State{Addresses: endpoints})
+	}
+}
+
+func (r *periodicDNSResolver) loop() {
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			r.resolve()
+		case <-r.ctx.Done():
+			return
+		}
+	}
+}
+
+func (r *periodicDNSResolver) ResolveNow(resolver.ResolveNowOptions) {
+	r.resolve()
+}
+
+func (r *periodicDNSResolver) Close() {
+	r.closeOnce.Do(func() { r.cancel() })
+}
+
+func parseHostPort(endpoint string) (string, string, error) {
+	host, port, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		host = endpoint
+		port = "443"
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		return "", "", err
+	}
+	return host, port, nil
+}

--- a/client/grpc/resolver_test.go
+++ b/client/grpc/resolver_test.go
@@ -1,0 +1,148 @@
+package grpc
+
+import (
+	"net"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/serviceconfig"
+)
+
+func TestPeriodicDNSResolverBuilder_Scheme(t *testing.T) {
+	c := qt.New(t)
+	b := PeriodicDNSResolverBuilder(30 * time.Second)
+	c.Assert(b.Scheme(), qt.Equals, DNSRefreshScheme)
+}
+
+func TestPeriodicDNSResolverBuilder_DefaultInterval(t *testing.T) {
+	c := qt.New(t)
+	b := PeriodicDNSResolverBuilder(0).(*periodicDNSBuilder)
+	c.Assert(b.interval, qt.Equals, DefaultDNSRefreshInterval)
+}
+
+type fakeCC struct {
+	mu    sync.Mutex
+	state resolver.State
+	err   error
+	calls int
+}
+
+func (f *fakeCC) UpdateState(s resolver.State) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.state = s
+	f.calls++
+	return nil
+}
+
+func (f *fakeCC) ReportError(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.err = err
+}
+
+func (f *fakeCC) NewAddress([]resolver.Address)                             {}
+func (f *fakeCC) ParseServiceConfig(string) *serviceconfig.ParseResult      { return nil }
+func (f *fakeCC) NewServiceConfig(string)                                   {}
+
+func (f *fakeCC) getState() (resolver.State, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.state, f.calls
+}
+
+func buildTarget(host string) resolver.Target {
+	u, _ := url.Parse(DNSRefreshScheme + ":///" + host)
+	return resolver.Target{URL: *u}
+}
+
+func TestPeriodicDNSResolver_ResolvesOnBuild(t *testing.T) {
+	c := qt.New(t)
+
+	cc := &fakeCC{}
+	b := PeriodicDNSResolverBuilder(1 * time.Hour)
+	r, err := b.Build(buildTarget("localhost:12345"), cc, resolver.BuildOptions{})
+	c.Assert(err, qt.IsNil)
+	defer r.Close()
+
+	state, calls := cc.getState()
+	c.Assert(calls, qt.Not(qt.Equals), 0, qt.Commentf("Build should trigger initial resolve"))
+	c.Assert(len(state.Addresses) > 0, qt.IsTrue, qt.Commentf("localhost should resolve to at least one address"))
+
+	foundPort := false
+	for _, addr := range state.Addresses {
+		_, port, _ := net.SplitHostPort(addr.Addr)
+		if port == "12345" {
+			foundPort = true
+			break
+		}
+	}
+	c.Assert(foundPort, qt.IsTrue, qt.Commentf("resolved addresses should use the target port"))
+}
+
+func TestPeriodicDNSResolver_ReResolvesOnTick(t *testing.T) {
+	c := qt.New(t)
+
+	cc := &fakeCC{}
+	b := PeriodicDNSResolverBuilder(50 * time.Millisecond)
+	r, err := b.Build(buildTarget("localhost:9999"), cc, resolver.BuildOptions{})
+	c.Assert(err, qt.IsNil)
+	defer r.Close()
+
+	_, initialCalls := cc.getState()
+	c.Assert(initialCalls, qt.Not(qt.Equals), 0)
+
+	time.Sleep(200 * time.Millisecond)
+
+	_, afterCalls := cc.getState()
+	c.Assert(afterCalls > initialCalls, qt.IsTrue,
+		qt.Commentf("should have re-resolved; initial=%d after=%d", initialCalls, afterCalls))
+}
+
+func TestPeriodicDNSResolver_StopsOnClose(t *testing.T) {
+	c := qt.New(t)
+
+	cc := &fakeCC{}
+	b := PeriodicDNSResolverBuilder(50 * time.Millisecond)
+	r, err := b.Build(buildTarget("localhost:9999"), cc, resolver.BuildOptions{})
+	c.Assert(err, qt.IsNil)
+
+	time.Sleep(150 * time.Millisecond)
+	r.Close()
+
+	_, callsAtClose := cc.getState()
+	time.Sleep(200 * time.Millisecond)
+	_, callsAfter := cc.getState()
+	c.Assert(callsAfter, qt.Equals, callsAtClose,
+		qt.Commentf("no re-resolution after Close; atClose=%d after=%d", callsAtClose, callsAfter))
+}
+
+func TestParseHostPort(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantHost string
+		wantPort string
+		wantErr  bool
+	}{
+		{"myhost:8091", "myhost", "8091", false},
+		{"myhost", "myhost", "443", false},
+		{"127.0.0.1:80", "127.0.0.1", "80", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			c := qt.New(t)
+			host, port, err := parseHostPort(tt.input)
+			if tt.wantErr {
+				c.Assert(err, qt.Not(qt.IsNil))
+				return
+			}
+			c.Assert(err, qt.IsNil)
+			c.Assert(host, qt.Equals, tt.wantHost)
+			c.Assert(port, qt.Equals, tt.wantPort)
+		})
+	}
+}


### PR DESCRIPTION
**Because**

- The built-in gRPC `dns:///` resolver only re-resolves on subchannel failure
- When HPA adds new pods behind headless K8s services, existing gRPC clients never discover them
- This causes CPU skew where all traffic pins to the original pods

**This commit**

- Adds a `dns-refresh:///` resolver that periodically (every 30s) looks up DNS A records and pushes updated addresses to the round_robin balancer
- Updates `x/client/grpc` `newConn()` — covers ALL backend-to-backend gRPC connections
- Updates `x/acl` `InitOpenFGAClient` — covers all OpenFGA gRPC connections
- Includes unit tests for the periodic resolver and updates existing tests


Made with [Cursor](https://cursor.com)